### PR TITLE
#293 UX: Added line break before party url.

### DIFF
--- a/parties/templates/parties/show.html
+++ b/parties/templates/parties/show.html
@@ -125,9 +125,9 @@
 			{% endif %}
 
 			{% if party.website %}
-				<li><a href="{{ party.website }}">{{ party.website }}</a></li>
+				<br/><a href="{{ party.website }}">{{ party.website }}</a>
 			{% elif party.party_series.website %}
-				<li><a href="{{ party.party_series.website }}">{{ party.party_series.website }}</a></li>
+				<br/><a href="{{ party.party_series.website }}">{{ party.party_series.website }}</a>
 			{% endif %}
 		</ul>
 	</div>


### PR DESCRIPTION
Addresses #293

Tested on Chrome (Windows) & Safari (Mac) , screenshots:

![Screenshot 2019-03-27 at 00 41 45](https://user-images.githubusercontent.com/3512672/55042589-17d20880-502a-11e9-9001-76b72c24798a.png)
![Screenshot 2019-03-27 at 00 42 10](https://user-images.githubusercontent.com/3512672/55042590-17d20880-502a-11e9-9e22-b5268063308d.png)

-----

Tested on mobile:

![Screenshot 2019-03-27 at 00 43 07](https://user-images.githubusercontent.com/3512672/55042602-202a4380-502a-11e9-9178-0f4c4788ed50.png)

for @sagamusix  :)
pr for review @nswaldman @gasman @emoon @glennlunder 