### PR TITLE
Update _webfonts.scss

### DIFF
--- a/src/style/_legacy/fonts/_webfonts.scss
+++ b/src/style/_legacy/fonts/_webfonts.scss
@@ -6,6 +6,7 @@
 	url('/static/font/fabrica/fabrica-webfont.woff') format('woff'),
 	url('/static/font/fabrica/fabrica-webfont.ttf') format('truetype'),
 	url('/static/font/fabrica/fabrica-webfont.svg#FabricaRegular') format('svg');
+	font-display: fallback;
 	font-weight: normal;
 	font-style: normal;
 }
@@ -16,6 +17,7 @@
 	url('/static/font/dejavusansmono_book/DejaVuSansMono-webfont.woff') format('woff'),
 	url('/static/font/dejavusansmono_book/DejaVuSansMono-webfont.ttf') format('truetype'),
 	url('/static/font/dejavusansmono_book/DejaVuSansMono-webfont.svg#dejavu_sans_monobook') format('svg');
+	font-display: fallback;
 	font-weight: normal;
 	font-style: normal;
 }


### PR DESCRIPTION
By default, most browsers do not display text until after a custom font has downloaded and initialised or after a 3 second timeout has passed. There is a newish `font-display` descriptor will tell a browser to show the text first using a generic font and then apply the custom font when it is ready.

https://developers.google.com/web/updates/2016/02/font-display
https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display