### PR TITLE
Archive AsciiArena links

### DIFF
--- a/demoscene/utils/groklinks.py
+++ b/demoscene/utils/groklinks.py
@@ -1592,6 +1592,7 @@ ARCHIVED_LINK_TYPES = [
     'LanyrdEvent',
     'GooglePlusPage', 'GooglePlusEvent',
     'CappedVideo',
+    'AsciiarenaArtist', 'AsciiarenaCrew', 'AsciiarenaRelease',
 ]
 
 


### PR DESCRIPTION
Originally discussed via Slack, this website currently displays "Parked" placeholder page. This pull request archives these links so they are not shown in production page nor edited (by normal user?)

Thanks.