### PR TITLE
remove djcelery in favour of celery's own django integration

### DIFF
--- a/demoscene/tasks.py
+++ b/demoscene/tasks.py
@@ -1,12 +1,12 @@
 from __future__ import absolute_import, unicode_literals
 
-from celery.task import task
+from celery import shared_task
 
 from parties.models import Party
 from sceneorg.models import File
 
 
-@task(rate_limit='6/m', ignore_result=True)
+@shared_task(rate_limit='6/m', ignore_result=True)
 def add_sceneorg_results_file_to_party(party_id, file_id):
     party = Party.objects.get(id=party_id)
     file = File.objects.get(id=file_id)

--- a/demozoo/__init__.py
+++ b/demozoo/__init__.py
@@ -1,0 +1,3 @@
+from __future__ import absolute_import
+
+from .celery import app as celery_app

--- a/demozoo/celery.py
+++ b/demozoo/celery.py
@@ -1,0 +1,19 @@
+from __future__ import absolute_import
+
+import os
+import dotenv
+
+from celery import Celery
+
+env_file = os.path.join(os.path.dirname(os.path.dirname(os.path.realpath(__file__))), '.env')
+dotenv.read_dotenv(env_file)
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'demozoo.settings.dev')
+
+from django.conf import settings
+
+app = Celery('demozoo')
+
+# Using a string here means the worker will not have to
+# pickle the object when using Windows.
+app.config_from_object('django.conf:settings')
+app.autodiscover_tasks(lambda: settings.INSTALLED_APPS)

--- a/demozoo/settings/base.py
+++ b/demozoo/settings/base.py
@@ -217,6 +217,8 @@ CELERY_ROUTES = {
     'screenshots.tasks.create_screenshot_versions_from_local_file': {'queue': 'fasttrack'},
 }
 CELERYD_CONCURRENCY = 2
+CELERY_TASK_SERIALIZER = 'json'
+CELERY_ACCEPT_CONTENT = ['pickle', 'json']
 
 from datetime import timedelta
 CELERYBEAT_SCHEDULE = {

--- a/demozoo/settings/base.py
+++ b/demozoo/settings/base.py
@@ -133,7 +133,6 @@ INSTALLED_APPS = [
     'treebeard',
     'taggit',
     'compressor',
-    'djcelery',
     'rest_framework',
     'corsheaders',
 
@@ -213,8 +212,6 @@ COMPRESS_PRECOMPILERS = (
 REDIS_URL = 'redis://localhost:6379/0'
 
 # Celery settings
-import djcelery
-djcelery.setup_loader()
 BROKER_URL = REDIS_URL
 CELERY_ROUTES = {
     'screenshots.tasks.create_screenshot_versions_from_local_file': {'queue': 'fasttrack'},

--- a/demozoo/settings/test.py
+++ b/demozoo/settings/test.py
@@ -296,7 +296,7 @@ urllib.request.install_opener(urllib.request.build_opener(MockHTTPHandler, MockH
 COVERAGE_REPORT_HTML_OUTPUT_DIR = os.path.join(os.path.dirname(__file__), '..', '..', 'coverage')
 COVERAGE_MODULE_EXCLUDES = [
     'tests$', 'settings$', 'urls$', '^django',
-    '^compressor', '^debug_toolbar', 'migrations', '^djcelery',
+    '^compressor', '^debug_toolbar', 'migrations',
     '^rest_framework', '^south', '^taggit', '^treebeard'
 ]
 

--- a/etc/demozoo-celery-supervisor.conf
+++ b/etc/demozoo-celery-supervisor.conf
@@ -1,5 +1,5 @@
 [program:demozoo-celery]
-command=/home/demozoo/.virtualenvs/demozoo/bin/python manage.py celery worker --loglevel=INFO --time-limit=300 --concurrency=2 -Q fasttrack,celery
+command=/home/demozoo/.virtualenvs/demozoo/bin/celery -A demozoo worker --loglevel=INFO --time-limit=300 --concurrency=2 -Q fasttrack,celery
 directory=/home/demozoo/demozoo
 user=demozoo
 numprocs=1

--- a/etc/demozoo-celerybeat-supervisor.conf
+++ b/etc/demozoo-celerybeat-supervisor.conf
@@ -1,5 +1,5 @@
 [program:demozoo-celerybeat]
-command=/home/demozoo/.virtualenvs/demozoo/bin/python manage.py celery beat --schedule=/var/lib/celery/demozoo-celerybeat-schedule --loglevel=INFO
+command=/home/demozoo/.virtualenvs/demozoo/bin/celery -A demozoo beat --schedule=/var/lib/celery/demozoo-celerybeat-schedule --loglevel=INFO
 
 directory=/home/demozoo/demozoo
 user=demozoo

--- a/janeway/tasks.py
+++ b/janeway/tasks.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import, unicode_literals
 
-from celery.task import task
+from celery import shared_task
 
 from demoscene.models import Releaser, ReleaserExternalLink
 from janeway.matching import automatch_productions
@@ -10,18 +10,18 @@ from screenshots.models import PILConvertibleImage
 from screenshots.tasks import upload_original, upload_standard, upload_thumb
 
 
-@task(ignore_result=True)
+@shared_task(ignore_result=True)
 def automatch_all_authors():
     for releaser_id in ReleaserExternalLink.objects.filter(link_class='KestraBitworldAuthor').distinct().values_list('releaser_id', flat=True):
         automatch_author.delay(releaser_id)
 
 
-@task(rate_limit='6/m', ignore_result=True)
+@shared_task(rate_limit='6/m', ignore_result=True)
 def automatch_author(releaser_id):
     automatch_productions(Releaser.objects.get(id=releaser_id))
 
 
-@task(rate_limit='6/m', ignore_result=True)
+@shared_task(rate_limit='6/m', ignore_result=True)
 def import_screenshot(production_id, janeway_id, url, suffix):
     blob = fetch_origin_url(url)
     sha1 = blob.sha1

--- a/productions/tasks.py
+++ b/productions/tasks.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import, unicode_literals
 
-from celery.task import task
+from celery import shared_task
 import datetime
 
 from six.moves import urllib
@@ -8,7 +8,7 @@ from six.moves import urllib
 from productions.models import ProductionLink
 
 
-@task(rate_limit='12/m', ignore_result=True)
+@shared_task(rate_limit='12/m', ignore_result=True)
 def fetch_production_link_embed_data(productionlink_id):
     try:
         production_link = ProductionLink.objects.get(id=productionlink_id)
@@ -29,7 +29,7 @@ def fetch_production_link_embed_data(productionlink_id):
         production_link.save()
 
 
-@task(rate_limit='30/m', ignore_result=True)
+@shared_task(rate_limit='30/m', ignore_result=True)
 def clean_dead_youtube_link(productionlink_id):
     """Poll oembed endpoint for the given youtube link, and delete if it's a 404"""
     try:

--- a/requirements-production.txt
+++ b/requirements-production.txt
@@ -5,7 +5,6 @@ Markdown==2.4
 Pillow==6.2.1
 boto3>=1.14,<1.15
 celery==3.1.25
-django-celery>=3.2,<3.3
 django-compressor>=2.1,<2.2
 django-cors-headers>=1.3.0,<2
 django-storages>=1.9,<1.10

--- a/requirements-production.txt
+++ b/requirements-production.txt
@@ -6,7 +6,6 @@ Pillow==6.2.1
 boto3>=1.14,<1.15
 celery==3.1.25
 django-celery>=3.2,<3.3
-django-celery-with-redis==3.0
 django-compressor>=2.1,<2.2
 django-cors-headers>=1.3.0,<2
 django-storages>=1.9,<1.10

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,6 @@ Markdown==2.4
 Pillow==6.2.1
 boto3>=1.14,<1.15
 celery==3.1.25
-django-celery>=3.2,<3.3
 django-compressor>=2.1,<2.2
 django-cors-headers>=1.3.0,<2
 django-debug-toolbar>=1.11,<2

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,6 @@ Pillow==6.2.1
 boto3>=1.14,<1.15
 celery==3.1.25
 django-celery>=3.2,<3.3
-django-celery-with-redis==3.0
 django-compressor>=2.1,<2.2
 django-cors-headers>=1.3.0,<2
 django-debug-toolbar>=1.11,<2

--- a/sceneorg/tasks.py
+++ b/sceneorg/tasks.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import, unicode_literals
 
-from celery.task import task
+from celery import shared_task
 from sceneorg.models import Directory, File
 from sceneorg.dirparser import parse_all_dirs
 from demoscene.tasks import find_sceneorg_results_files
@@ -18,7 +18,7 @@ from django.conf import settings
 logger = logging.getLogger(__name__)
 
 
-@task(time_limit=3600, ignore_result=True)
+@shared_task(time_limit=3600, ignore_result=True)
 def fetch_new_sceneorg_files(days=1):
     url = "https://files.scene.org/api/adhoc/latest-files/?days=%d" % days
 
@@ -87,7 +87,7 @@ def fetch_new_sceneorg_files(days=1):
         find_sceneorg_results_files()
 
 
-@task(time_limit=7200, ignore_result=True)
+@shared_task(time_limit=7200, ignore_result=True)
 def scan_dir_listing():
     new_file_count = 0
     for path, entries in parse_all_dirs():

--- a/screenshots/tasks.py
+++ b/screenshots/tasks.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import, unicode_literals
 
-from celery.task import task
+from celery import shared_task
 import io
 import os
 import re
@@ -46,7 +46,7 @@ def upload_thumb(img, screenshot, basename):
     screenshot.thumbnail_width, screenshot.thumbnail_height = thumb_size
 
 
-@task(ignore_result=True)
+@shared_task(ignore_result=True)
 def create_screenshot_versions_from_local_file(screenshot_id, filename):
     try:
         screenshot = Screenshot.objects.get(id=screenshot_id)
@@ -72,7 +72,7 @@ def create_screenshot_versions_from_local_file(screenshot_id, filename):
 
 
 # token rate limit so that new uploads from local files get priority
-@task(rate_limit='1/s', ignore_result=True)
+@shared_task(rate_limit='1/s', ignore_result=True)
 def rebuild_screenshot(screenshot_id):
     try:
         screenshot = Screenshot.objects.get(id=screenshot_id)
@@ -98,7 +98,7 @@ def rebuild_screenshot(screenshot_id):
         pass
 
 
-@task(rate_limit='6/m', ignore_result=True)
+@shared_task(rate_limit='6/m', ignore_result=True)
 def create_screenshot_from_production_link(production_link_id):
     try:
         prod_link = ProductionLink.objects.get(id=production_link_id)
@@ -200,7 +200,7 @@ def capture_upload_for_processing(uploaded_file, screenshot_id):
     create_screenshot_versions_from_local_file.delay(screenshot_id, path)
 
 
-@task(ignore_result=True)
+@shared_task(ignore_result=True)
 def fetch_remote_screenshots():
     for prod_link in find_screenshottable_graphics():
         create_screenshot_from_production_link.delay(prod_link.id)


### PR DESCRIPTION
Prerequisite to upgrading to celery 4.x, which we need to upgrade from python 3.6: https://docs.celeryproject.org/en/stable/django/first-steps-with-django.html