### PR TITLE
Add 'prods without Pouet links' report

### DIFF
--- a/maintenance/forms.py
+++ b/maintenance/forms.py
@@ -7,3 +7,4 @@ from productions.models import ProductionType
 class ProductionFilterForm(forms.Form):
     platform = forms.ModelMultipleChoiceField(required=False, queryset=Platform.objects.all())
     production_type = forms.ModelMultipleChoiceField(required=False, queryset=ProductionType.objects.all())
+    release_year = forms.IntegerField(required=False)

--- a/maintenance/reports.py
+++ b/maintenance/reports.py
@@ -3,6 +3,7 @@ from django.conf import settings
 from django.db.models import Q
 
 from maintenance.models import Exclusion
+from pouet.matching import get_pouetable_prod_types
 from productions.models import Production, ProductionLink
 
 
@@ -150,6 +151,24 @@ class ProductionsWithoutVideosReport(FilteredProdutionsReport):
             .filter(links__is_download_link=True)
             .exclude(supertype__in=['music', 'graphics'])
             .exclude(tags__name__in=['lost', 'corrupted-file'])
+            .exclude(id__in=excluded_ids)
+            .values_list('id', flat=True)
+        )
+
+
+class ProductionsWithoutPouetLinksReport(FilteredProdutionsReport):
+    master_list_key = 'demozoo:productions:without_pouet_links'
+
+    @classmethod
+    def get_master_list(cls):
+        excluded_ids = Exclusion.objects.filter(
+            report_name='prods_without_pouet_links'
+        ).values_list('record_id', flat=True)
+
+        return (
+            Production.objects
+            .exclude(links__link_class='PouetProduction')
+            .filter(types__in=get_pouetable_prod_types())
             .exclude(id__in=excluded_ids)
             .values_list('id', flat=True)
         )

--- a/maintenance/tests/test_views.py
+++ b/maintenance/tests/test_views.py
@@ -52,6 +52,10 @@ class TestReports(TestCase):
         response = self.client.get('/maintenance/prods_without_videos')
         self.assertEqual(response.status_code, 200)
 
+    def test_prods_without_pouet_links(self):
+        response = self.client.get('/maintenance/prods_without_pouet_links')
+        self.assertEqual(response.status_code, 200)
+
     def test_prods_without_credits(self):
         response = self.client.get('/maintenance/prods_without_credits')
         self.assertEqual(response.status_code, 200)

--- a/maintenance/tests/test_views.py
+++ b/maintenance/tests/test_views.py
@@ -40,7 +40,7 @@ class TestReports(TestCase):
         zx = Platform.objects.get(name='ZX Spectrum')
         demo = ProductionType.objects.get(name='Demo')
         response = self.client.get(
-            '/maintenance/prods_without_screenshots?platform=%d&production_type=%d' % (zx.id, demo.id)
+            '/maintenance/prods_without_screenshots?platform=%d&production_type=%d&release_year=2000' % (zx.id, demo.id)
         )
         self.assertEqual(response.status_code, 200)
 

--- a/maintenance/views.py
+++ b/maintenance/views.py
@@ -81,12 +81,15 @@ class FilterableProductionReport(Report):
         if filter_form.is_valid():
             platform_ids = [platform.id for platform in filter_form.cleaned_data['platform']]
             prod_type_ids = [typ.id for typ in filter_form.cleaned_data['production_type']]
+            release_year = filter_form.cleaned_data['release_year']
         else:
             platform_ids = []
             prod_type_ids = []
+            release_year = None
 
         productions, total_count = self.report_class.run(
-            limit=self.limit, platform_ids=platform_ids, production_type_ids=prod_type_ids
+            limit=self.limit, platform_ids=platform_ids, production_type_ids=prod_type_ids,
+            release_year=release_year
         )
 
         context.update({

--- a/maintenance/views.py
+++ b/maintenance/views.py
@@ -115,6 +115,12 @@ class ProdsWithoutVideoCaptures(FilterableProductionReport):
     report_class = reports_module.ProductionsWithoutVideosReport
 
 
+class ProdsWithoutPouetLinks(FilterableProductionReport):
+    title = "Productions without Pouet links"
+    name = 'prods_without_pouet_links'
+    report_class = reports_module.ProductionsWithoutPouetLinksReport
+
+
 class ProdsWithoutCredits(FilterableProductionReport):
     title = "Productions without individual credits"
     name = 'prods_without_credits'
@@ -1667,6 +1673,7 @@ reports = [
             ProdsWithoutExternalLinks,
             ProdsWithoutScreenshots,
             ProdsWithoutVideoCaptures,
+            ProdsWithoutPouetLinks,
             ProdsWithoutCredits,
             ProdsWithoutPlatforms,
             ProdsWithoutPlatformsExcludingLost,

--- a/src/style/_legacy/components/production_listing_filters.scss
+++ b/src/style/_legacy/components/production_listing_filters.scss
@@ -16,6 +16,7 @@
             display: inline;
             width: 50%;
             padding-right: 10px;
+            vertical-align: top;
 
             label {
                 vertical-align: top;


### PR DESCRIPTION
Also add a 'release year' filter to the other filterable "prods without X" reports.

This is mostly so that I can get Pouet cross-links for 2021 releases as complete as possible for the benefit of the Meteoriks (and rule out the possibility that there's a hidden gem that only exists on Demozoo that everyone misses because they're only looking at Pouet data)