### PR TITLE
Switch to europarse for date parsing

### DIFF
--- a/lib/fuzzy_date.py
+++ b/lib/fuzzy_date.py
@@ -2,7 +2,7 @@ import calendar
 import datetime
 import re
 
-import dateutil.parser
+import europarse.parser
 
 
 MONTHS = (
@@ -120,7 +120,7 @@ class FuzzyDate(object):
         # using this as the default ensures that it doesn't try to fill in day/month with the current one,
         # leading to much hilarity when entering 'February 1996' on the 30th of the month - while still
         # allowing 'February' as a valid synonym for February of this year
-        date = dateutil.parser.parse(str, dayfirst=True, default=this_year).date()
+        date = europarse.parser.parse(str, dayfirst=True, default=this_year).date()
         if YEAR_REGEX.match(str):
             return FuzzyDate(date, 'y')
         elif MONTH_REGEX.match(str):

--- a/requirements-production.txt
+++ b/requirements-production.txt
@@ -20,19 +20,12 @@ unidecode==0.04.14
 bcrypt>=3.1,<3.2  # 3.2 drops py2.7
 django-dotenv>=1.4.2,<2.0
 ansipants>=0.1.2,<1.0
-
-# pinned because newer versions keep breaking shit
-# https://github.com/dateutil/dateutil/issues/1071
-# https://github.com/dateutil/dateutil/issues/402
-python-dateutil==2.5.1
-
-# freezegun >= 0.3.15 depends on python-dateutil having a property dateutil.tz.UTC,
-# which only exists on shitty broken versions (>=2.7) of python-dateutil
-freezegun==0.3.14
+europarse>=1.0.0,<2
 
 # needed to keep django-compressor happy when analysing django-filter templates
 django-crispy-forms>=1.13.0,<1.14
 
+freezegun>=1.2.2,<2
 uWSGI==2.0.15
 mock>=3.0,<4.0
 requests>=2.22,<3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,19 +24,12 @@ django-extensions>=3.1,<3.2
 coverage>=5.0,<6.0
 django-dotenv>=1.4.2,<2.0
 ansipants>=0.1.2,<1.0
-
-# pinned because newer versions keep breaking shit
-# https://github.com/dateutil/dateutil/issues/1071
-# https://github.com/dateutil/dateutil/issues/402
-python-dateutil==2.5.1
-
-# freezegun >= 0.3.15 depends on python-dateutil having a property dateutil.tz.UTC,
-# which only exists on shitty broken versions (>=2.7) of python-dateutil
-freezegun==0.3.14
+europarse>=1.0.0,<2
 
 # needed to keep django-compressor happy when analysing django-filter templates
 django-crispy-forms>=1.13.0,<1.14
 
+freezegun>=1.2.2,<2
 mock>=3.0,<4.0
 requests>=2.22,<3.0
 responses>=0.10,<0.11


### PR DESCRIPTION
Currently we are using an ancient version (2.5.1) of python-dateutil for date parsing, because newer versions broke the parser so that it can't simultaneously parse European dd/mm/yyyy dates and ISO YYYY-MM-DD dates. This prevents us from upgrading past Python 3.9.

Since this shows no sign of being fixed any time soon, switch to europarse, our shiny new fork of the last good version of dateutil.parser updated for current Python versions: https://github.com/demozoo/europarse