### PR TITLE
Nano award recommendation tweaks

### DIFF
--- a/awards/views.py
+++ b/awards/views.py
@@ -121,7 +121,7 @@ def candidates(request, event_slug, category_slug):
     productions = category.eligible_productions().prefetch_related(
         'author_nicks__releaser', 'author_affiliation_nicks__releaser',
         'types', 'platforms',
-    ).order_by('sortable_title')
+    ).order_by('-types__path', 'sortable_title')
 
     production_page = get_page(
         productions,

--- a/productions/templates/productions/_award_recommendations.html
+++ b/productions/templates/productions/_award_recommendations.html
@@ -1,0 +1,67 @@
+{% for event, recommendation_options in awards_accepting_recommendations %}
+<div class="award-recommendation">
+    {% if request.user.is_authenticated %}
+        <header class="award-recommendation__header">
+            <h2 class="award-recommendation__heading">
+                Recommend this production for <span class="award-recommendation__name">{{ event.name }}</span>!
+            </h2>
+        </header>
+        <div class="award-recommendation__inner">
+            <form action="{% url 'awards_recommend' event.slug production.id %}"
+                  class="award-recommendation__form"
+                  method="POST">
+                {% csrf_token %}
+                {% if recommendation_options|length > 1 %}
+                    <fieldset class="award-recommendation__fieldset">
+                        <ul class="award-recommendation__categories">
+                            {% for category_id, category_name, has_recommended in recommendation_options %}
+                            <li class="award-recommendation__category">
+                                <label class="award-recommendation__label">
+                                    <input class="award-recommendation__checkbox"
+                                        id="award_recommendation_category_{{ category_id }}"
+                                        name="category_id" value="{{ category_id }}"
+                                        type="checkbox"
+                                        {% if has_recommended %}checked="checked"{% endif %} />
+                                    <span class="award-recommendation__label-text">{{ category_name }}</span>
+                                </label>
+                            </li>
+                            {% endfor %}
+                        </ul>
+                    </fieldset>
+                    <div class="award-recommendation__buttons">
+                        <button class="button button--ghost" type="submit">Make your recommendation!</button>
+                    </div>
+                {% else %}
+                    {# only one category in recommendation_options, but use a for loop to assign the vars #}
+                    {% for category_id, category_name, has_recommended in recommendation_options %}
+                        <fieldset class="award-recommendation__fieldset">
+                            <p class="award-recommendation__category">
+                                {% if has_recommended %}
+                                    You have already recommended this production for the <b>{{ category_name }}</b> category
+                                {% else %}
+                                    <input type="hidden" name="category_id" value="{{ category_id }}">
+                                    Recommending this production for the <b>{{ category_name }}</b> category
+                                {% endif %}
+                            </p>
+                        </fieldset>
+                        <div class="award-recommendation__buttons">
+                            {% if has_recommended %}
+                                <button class="button button--ghost" type="submit">Remove your recommendation</button>
+                            {% else %}
+                                <button class="button button--ghost" type="submit">Make your recommendation!</button>
+                            {% endif %}
+                        </div>
+                    {% endfor %}
+                {% endif %}
+            </form>
+        </div>
+    {% else %}
+        <header class="award-recommendation__header">
+            <a class="award-recommendation__login-link"
+               href="{% url 'log_in' %}?next={{ production.get_absolute_url|urlencode }}">
+                <h2 class="award-recommendation__heading">Recommend this production for {{ event.name }}!</h2>
+            </a>
+        </header>
+    {% endif %}
+</div>
+{% endfor %}

--- a/productions/templates/productions/show.html
+++ b/productions/templates/productions/show.html
@@ -62,50 +62,7 @@
     {% endif %}
 
     {% if site_is_writeable %}
-        {% for event, recommendation_options in awards_accepting_recommendations %}
-            <div class="award-recommendation">
-                {% if request.user.is_authenticated %}
-                    <header class="award-recommendation__header">
-                        <h2 class="award-recommendation__heading">
-                            Recommend this production for <span class="award-recommendation__name">{{ event.name }}</span>!
-                        </h2>
-                    </header>
-                    <div class="award-recommendation__inner">
-                        <form action="{% url 'awards_recommend' event.slug production.id %}"
-                              class="award-recommendation__form"
-                              method="POST">
-                            <fieldset class="award-recommendation__fieldset">
-                                {% csrf_token %}
-                                <ul class="award-recommendation__categories">
-                                    {% for category_id, category_name, has_recommended in recommendation_options %}
-                                    <li class="award-recommendation__category">
-                                        <label class="award-recommendation__label">
-                                            <input class="award-recommendation__checkbox"
-                                                   id="award_recommendation_category_{{ category_id }}"
-                                                   name="category_id" value="{{ category_id }}"
-                                                   type="checkbox"
-                                                   {% if has_recommended %}checked="checked"{% endif %} />
-                                            <span class="award-recommendation__label-text">{{ category_name }}</span>
-                                        </label>
-                                    </li>
-                                    {% endfor %}
-                                </ul>
-                            </fieldset>
-                            <div class="award-recommendation__buttons">
-                                <button class="button button--ghost" type="submit">Make your recommendation!</button>
-                            </div>
-                        </form>
-                    </div>
-                {% else %}
-                    <header class="award-recommendation__header">
-                        <a class="award-recommendation__login-link"
-                           href="{% url 'log_in' %}?next={{ production.get_absolute_url|urlencode }}">
-                            <h2 class="award-recommendation__heading">Recommend this production for {{ event.name }}!</h2>
-                        </a>
-                    </header>
-                {% endif %}
-            </div>
-        {% endfor %}
+        {% include "productions/_award_recommendations.html" %}
     {% endif %}
 
     <div class="mainstage">


### PR DESCRIPTION
* Order the candidate listing pages by production type (in descending path order, so that for intros they show up as largest size first)
* Take account of the defined platforms for award categories when listing the available categories for a production
* If only one award category is available, provide an alternative confirmation box that skips the need to tick a checkbox