### PR TITLE
16colors content tags and magazine support.

### DIFF
--- a/demoscene/utils/groklinks.py
+++ b/demoscene/utils/groklinks.py
@@ -1605,6 +1605,11 @@ class SixteenColorsGroup(UrlPattern):
     pattern = '/group/<slug>'
 
 
+class SixteenColorsMag(UrlPattern):
+    site = sixteencolors
+    pattern = '/mag/<slug>'
+
+
 class SixteenColorsContent(UrlPattern):
     site = sixteencolors
     pattern = '/tags/content/<slug>'
@@ -1769,7 +1774,7 @@ PRODUCTION_LINK_TYPES = [
     AsciiarenaRelease, KestraBitworldRelease, StonishDisk, ArtcityImage,
     ScenesatTrack, ModlandFile, SoundcloudTrack, HearthisTrack, BandcampTrack, CsdbMusic, NectarineSong,
     ModarchiveModule, BitjamSong, PushnpopProduction, SpotifyTrack, Plus4WorldProduction,
-    SpeccyPlProduction, AtarikiEntry, SixteenColorsPack, ShadertoyShader,
+    SpeccyPlProduction, AtarikiEntry, SixteenColorsPack, SixteenColorsMag, ShadertoyShader,
     AmigascneFile, PaduaOrgFile,  # sites mirrored by scene.org - must come before SceneOrgFile
     SceneOrgFile, FujiologyFile, UntergrundFile, GithubAccount, GithubRepo, GithubDirectory,
     WikipediaPage, SpeccyWikiPage, AtarimaniaPage, HallOfLightGame, PixeljointImage,

--- a/demoscene/utils/groklinks.py
+++ b/demoscene/utils/groklinks.py
@@ -1605,6 +1605,16 @@ class SixteenColorsGroup(UrlPattern):
     pattern = '/group/<slug>'
 
 
+class SixteenColorsContent(UrlPattern):
+    site = sixteencolors
+    pattern = '/tags/content/<slug>'
+
+
+class SixteenColorsMagazine(UrlPattern):
+    site = sixteencolors
+    pattern = '/tags/magazine/<slug>'
+
+
 shadertoy = Site("Shadertoy", url='https://www.shadertoy.com/')
 
 
@@ -1748,8 +1758,8 @@ RELEASER_LINK_TYPES = [
     GithubAccount, GithubRepo, AtarimaniaPage, GameboyDemospottingAuthor, PixeljointArtist,
     ZxArtAuthor, ZxTunesArtist, InternetArchivePage,
     Plus4WorldGroup, Plus4WorldMember, BandcampArtist, VimeoUser, SpeccyPlAuthor, AtarikiEntry,
-    SixteenColorsArtist, SixteenColorsGroup, ShadertoyUser, Tic80Dev, Pico8User,
-    LinkedInUser, InstagramAccount, PolyworkUser, TikTokUser, MastodonAccount,
+    SixteenColorsArtist, SixteenColorsGroup, SixteenColorsContent, SixteenColorsMagazine, ShadertoyUser, 
+    Tic80Dev, Pico8User, LinkedInUser, InstagramAccount, PolyworkUser, TikTokUser, MastodonAccount,
     WaybackMachinePage, BaseUrl,
 ]
 
@@ -1797,7 +1807,7 @@ PARTY_LINK_TYPES = [
 BBS_LINK_TYPES = [
     PouetBBS, CsdbBBS, KestraBitworldAuthor, BBSmatesBBS, Defacto2Group, TelnetBBSGuideBBS,
     TwitterAccount, YoutubeUser, YoutubeChannel, TwitchChannel, FacebookPage, WikipediaPage,
-    SpeccyWikiPage, AtarikiEntry, InstagramAccount,
+    SpeccyWikiPage, AtarikiEntry, SixteenColorsContent, InstagramAccount,
     WaybackMachinePage, BaseUrl
 ]
 


### PR DESCRIPTION
This PR adds support for [16colors content]() and [magazine tags](https://16colo.rs/mags/1996/).

16colors doesn't have dedicated pages for BBSes but it does use content tags to group artworks for individual boards, such as [_broons bane_](https://16colo.rs/tags/content/broons%20bane).

![Screenshot from 2023-01-07 14-07-55](https://user-images.githubusercontent.com/513842/211128703-35b501f0-4703-4a0c-bad4-c8061c9a421b.png)

![Screenshot from 2023-01-07 14-14-59](https://user-images.githubusercontent.com/513842/211128930-4fd5efef-416d-4b95-b0f9-ea86cdb14022.png)

---

They also have tags for magazines such as _[corruption](https://16colo.rs/tags/magazine/corruption)_ which is different to the content tag _[corruption](https://16colo.rs/tags/content/corruption)_. And individual issues can also be linked, _[cor1](https://16colo.rs/mag/cor1/)_.

#### live site
![Screenshot from 2023-01-07 13-54-58](https://user-images.githubusercontent.com/513842/211128652-caf2adc9-5421-4438-ba91-b7489d585f6b.png)

#### PR
![Screenshot from 2023-01-07 13-55-10](https://user-images.githubusercontent.com/513842/211128654-2dc4788f-d800-4ecc-92a3-bfacca774fb4.png)

![Screenshot from 2023-01-07 14-44-52](https://user-images.githubusercontent.com/513842/211129989-deebc289-3206-490d-9e2a-e63d1522354c.png)
