### PR TITLE
Reject youtube video IDs with invalid characters

### DIFF
--- a/demoscene/tests/test_groklinks.py
+++ b/demoscene/tests/test_groklinks.py
@@ -180,6 +180,11 @@ class TestLinkRecognition(TestCase):
         self.assertEqual(link.link_class, 'BaseUrl')
         self.assertEqual(link.parameter, 'https://www.youtube.com/watch?t=250')
 
+        link.url = 'https://www.youtube.com/watch?v=r5sH2yZFY6whttp://csdb.dk/release/?id=51348'
+        self.assertEqual(str(link.link), 'https://www.youtube.com/watch?v=r5sH2yZFY6whttp://csdb.dk/release/?id=51348')
+        self.assertEqual(link.link_class, 'BaseUrl')
+        self.assertEqual(link.parameter, 'https://www.youtube.com/watch?v=r5sH2yZFY6whttp://csdb.dk/release/?id=51348')
+
     def test_discogs_release(self):
         cybrev = Production.objects.get(title="Cybernoid's Revenge")
         link = ProductionLink(production=cybrev, is_download_link=True)

--- a/demoscene/utils/groklinks.py
+++ b/demoscene/utils/groklinks.py
@@ -949,10 +949,14 @@ class YoutubeVideo(AbstractBaseUrl):
         if regex.match(urlstring):
             querystring = urllib.parse.parse_qs(url.query)
             try:
+                video_id = querystring['v'][0]
+                if not re.fullmatch(r'[\w\-\_]+', video_id):
+                    return None
+
                 if 't' in querystring:
-                    return "%s/%s" % (querystring['v'][0], querystring['t'][0])
+                    return "%s/%s" % (video_id, querystring['t'][0])
                 else:
-                    return querystring['v'][0]
+                    return video_id
             except KeyError:
                 return None
 


### PR DESCRIPTION
If the `v` parameter of a regular Youtube link contains multiple slashes (for example, someone has pasted another URL after it) this will dutifully be saved to the database as the parameter. However, since we represent timestamped links as `<video_id>/<timestamp>`, unpacking it again (to output the URL) will lead to it trying to split on slashes, and that code doesn't account for the possibility of more than one slash. Fix this by properly rejecting video IDs with invalid characters in them.