### PR TITLE
add band-aid to avoid large urls breaking layout

### DIFF
--- a/src/style/_legacy/pages/home.scss
+++ b/src/style/_legacy/pages/home.scss
@@ -151,14 +151,18 @@
 
     .comments {
         margin-bottom: 20px;
+
         ul {
             clear: both;
             padding-top: 8px;
+
             li {
+                border-bottom: 1px dotted #888;
                 clear: both;
                 margin: 8px 0;
+                overflow: hidden;
                 padding-bottom: 8px;
-                border-bottom: 1px dotted #888;
+
                 q {
                     font-style: italic;
                 }


### PR DESCRIPTION
Quick band-aid to prevent large non-breaking text from peeping outside of a comment's container. The reported case was a rather generous archive.org url.

A more flexible/robust solution would be to offer markdown in comments, like elsewhere in the site. This is a separate discussion though.