### PR TITLE
Prevent editing party organiser credits for a locked scener via the party page

### DIFF
--- a/parties/templates/parties/edit_organiser_protected.html
+++ b/parties/templates/parties/edit_organiser_protected.html
@@ -1,0 +1,5 @@
+{% extends base_template_with_ajax_option %}
+
+{% block base_main %}
+    <p>The scener profile for {{ organiser.releaser.name }} has been protected and cannot be edited. If you know something we don't, please <a href="/forums/3/">let us know in this thread</a>.</p>
+{% endblock %}

--- a/parties/views/parties.py
+++ b/parties/views/parties.py
@@ -5,6 +5,7 @@ from urllib.parse import urlencode
 
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
+from django.core.exceptions import PermissionDenied
 from django.db.models.functions import Lower
 from django.http import HttpResponse, HttpResponseRedirect
 from django.shortcuts import get_object_or_404, redirect, render
@@ -544,6 +545,8 @@ class RemoveOrganiserView(AjaxConfirmationView):
     def get_object(self, request, party_id, organiser_id):
         self.party = Party.objects.get(id=party_id)
         self.organiser = Organiser.objects.get(party=self.party, id=organiser_id)
+        if self.organiser.releaser.locked and not request.user.is_staff:
+            raise PermissionDenied
 
     def get_redirect_url(self):
         return self.party.get_absolute_url() + "?editing=organisers"

--- a/parties/views/parties.py
+++ b/parties/views/parties.py
@@ -526,6 +526,17 @@ def edit_organiser(request, party_id, organiser_id):
             })
             if form.is_valid():
                 releaser = form.cleaned_data['releaser_nick'].commit().releaser
+                if releaser.locked and not request.user.is_staff:
+                    messages.error(
+                        request,
+                        format_html(
+                            "The scener profile for {} is protected and cannot be added as an organiser. "
+                            'If you wish to add this organiser, <a href="/forums/3/">let us know in this thread</a>.',
+                            releaser.name
+                        )
+                    )
+                    return HttpResponseRedirect(party.get_absolute_url() + "?editing=organisers")
+
                 organiser.releaser = releaser
                 organiser.role = form.cleaned_data['role']
                 organiser.save()


### PR DESCRIPTION
Close the loophole where party organiser credits for a locked scener can still be edited from the party page.