### PR TITLE
Show release counts on scener/group profile pages

### DIFF
--- a/demoscene/templates/groups/show.html
+++ b/demoscene/templates/groups/show.html
@@ -237,21 +237,12 @@
                 </ul>
             </div>
         {% endif %}
-        <div class="panel editable_chunk">
-            <h3 class="panel__title productions_header">Productions</h3>
-            {% if prompt_to_edit %}
-                <ul class="actions">
-                    <li>
-                        <a href="{% url 'new_production' %}?releaser_id={{ group.id }}" class="action_button icon add open_in_lightbox edit_chunk" rel="nofollow">Add production</a>
-                    </li>
-                </ul>
-            {% endif %}
-            {% combined_releases group %}
-        </div>
+
+        {% combined_releases group %}
 
         {% if member_productions %}
             <div class="panel">
-                <h3 class="panel__title member_productions_header">Member productions</h3>
+                <h3 class="panel__title member_productions_header">Member productions ({{ member_productions|length }})</h3>
 
                 {% production_listing member_productions show_screenshots=1 show_prod_types=1 %}
             </div>

--- a/demoscene/templates/sceners/show.html
+++ b/demoscene/templates/sceners/show.html
@@ -223,18 +223,7 @@
             </div>
         {% endif %}
 
-        <div class="panel editable_chunk">
-            <h3 class="panel__title productions_header">Productions</h3>
-            {% if prompt_to_edit %}
-                <ul class="actions">
-                    <li>
-                        <a href="{% url 'new_production' %}?releaser_id={{ scener.id }}" class="action_button icon add open_in_lightbox edit_chunk" rel="nofollow">Add production</a>
-                    </li>
-                </ul>
-            {% endif %}
-
-            {% combined_releases scener %}
-        </div>
+        {% combined_releases scener %}
     </div>
 
     {% last_edited_by scener %}

--- a/demoscene/templatetags/releaser_tags.py
+++ b/demoscene/templatetags/releaser_tags.py
@@ -8,8 +8,8 @@ from productions.models import Screenshot
 register = template.Library()
 
 
-@register.inclusion_tag('shared/credited_production_listing.html')
-def combined_releases(releaser):
+@register.inclusion_tag('shared/credited_production_listing.html', takes_context=True)
+def combined_releases(context, releaser):
 
     credits = (
         releaser.credits().select_related('nick')
@@ -64,4 +64,5 @@ def combined_releases(releaser):
     return {
         'releaser': releaser,
         'credits': credits_with_prods_and_screenshots,
+        'prompt_to_edit': context.get('prompt_to_edit', False),
     }

--- a/demozoo/templates/shared/credited_production_listing.html
+++ b/demozoo/templates/shared/credited_production_listing.html
@@ -1,57 +1,67 @@
 {% load demoscene_tags %}
 
+<div class="panel editable_chunk">
+    <h3 class="panel__title productions_header">Productions ({{ credits|length }})</h3>
+    {% if prompt_to_edit %}
+        <ul class="actions">
+            <li>
+                <a href="{% url 'new_production' %}?releaser_id={{ releaser.id }}" class="action_button icon add open_in_lightbox edit_chunk" rel="nofollow">Add production</a>
+            </li>
+        </ul>
+    {% endif %}
 
-<table class="table">
-    <colgroup>
-        <col class="col--thumb" />
-        <col width="40%" />
-        <col />
-        <col class="col--date" />
-        {% if editing and site_is_writeable %}
-        <col />
-        {% endif %}
-    </colgroup>
-    <tbody>
-        {% for production, nick, credits, screenshot in credits %}
-            <tr>
-                <td>
-                    {% if screenshot %}
-                        {% microthumb screenshot %}
-
-                    {% else %}
-                        <div class="media media--thumbnail">
-                            {% icon production.supertype %}
-                        </div>
-                    {% endif %}
-                </td>
-                <td>
-                    <div>
-                        <a href="{{ production.get_absolute_url }}">{{ production.title }}</a>
-                        {% if credits %}
-                            -
-                            {% for credit in credits %}
-                                <span>{{ credit.description }}</span>{% if not forloop.last %},{% endif %}
-                            {% endfor %}
-                            {% if nick.name != releaser.name %}
-                                <em>(as <span>{{ nick.name }}</span>)</em>
-                            {% endif %}
-                        {% endif %}
-                    </div>
-                    <div class="meta">
-                        {{ production.platforms_and_types_list }}
-                    </div>
-                </td>
-                <td>{% byline production %}</td>
-                <td>{{ production.release_date.short_format }}</td>
-
-                {% if editing and site_is_writeable %}
+    <table class="table">
+        <colgroup>
+            <col class="col--thumb" />
+            <col width="40%" />
+            <col />
+            <col class="col--date" />
+            {% if editing and site_is_writeable %}
+            <col />
+            {% endif %}
+        </colgroup>
+        <tbody>
+            {% for production, nick, credits, screenshot in credits %}
+                <tr>
                     <td>
-                        <a href="{% url 'releaser_edit_credit' nick.releaser_id nick.id production.id %}" class="open_in_lightbox">
-                            <img src="/static/images/icons/edit.png" width="16" height="16" alt="Edit credit" title="Edit credit" />
-                        </a>
+                        {% if screenshot %}
+                            {% microthumb screenshot %}
+
+                        {% else %}
+                            <div class="media media--thumbnail">
+                                {% icon production.supertype %}
+                            </div>
+                        {% endif %}
                     </td>
-                {% endif %}
-            </tr>
-        {% endfor %}
-    </tbody>
-</table>
+                    <td>
+                        <div>
+                            <a href="{{ production.get_absolute_url }}">{{ production.title }}</a>
+                            {% if credits %}
+                                -
+                                {% for credit in credits %}
+                                    <span>{{ credit.description }}</span>{% if not forloop.last %},{% endif %}
+                                {% endfor %}
+                                {% if nick.name != releaser.name %}
+                                    <em>(as <span>{{ nick.name }}</span>)</em>
+                                {% endif %}
+                            {% endif %}
+                        </div>
+                        <div class="meta">
+                            {{ production.platforms_and_types_list }}
+                        </div>
+                    </td>
+                    <td>{% byline production %}</td>
+                    <td>{{ production.release_date.short_format }}</td>
+
+                    {% if editing and site_is_writeable %}
+                        <td>
+                            <a href="{% url 'releaser_edit_credit' nick.releaser_id nick.id production.id %}" class="open_in_lightbox">
+                                <img src="/static/images/icons/edit.png" width="16" height="16" alt="Edit credit" title="Edit credit" />
+                            </a>
+                        </td>
+                    {% endif %}
+                </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+</div>


### PR DESCRIPTION
Little feature request from OhLi / DDK - displaying release counts in the header bar of a scener / group's prod listing. Is this something we want - thoughts?

<img width="1219" alt="Screenshot 2023-09-30 at 22 27 54" src="https://github.com/demozoo/demozoo/assets/85097/672eb2c5-a285-428a-af9f-dc5a8f81cc09">
<img width="886" alt="Screenshot 2023-09-30 at 22 28 06" src="https://github.com/demozoo/demozoo/assets/85097/9ec5f5b9-b5c0-464a-bdcd-b9dfdb08d4f1">
