### PR TITLE
fixes button appearance when javascript is absent

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "demozoo",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Demozoo - The best demoscene website in the world.",
     "browserslist": [
       "defaults",

--- a/search/templates/search/search.html
+++ b/search/templates/search/search.html
@@ -35,9 +35,11 @@
                 <svg class="icon">
                     <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="{% static 'images/icons.svg' %}#icon--search"></use>
                 </svg>
-                <button type="submit" class="button button--search">
-                    <span class="button__text">Search</span>
-                </button>
+                <noscript>
+                    <button type="submit" class="button button--search">
+                        <span class="button__text">Search</span>
+                    </button>
+                </noscript>
             </div>
         </fieldset>
     </form>

--- a/src/style/_legacy/assets/search.scss
+++ b/src/style/_legacy/assets/search.scss
@@ -72,10 +72,11 @@
             &__text {
                 padding: 0 1em;
             }
+        }
 
-            .js & {
-                display: none;
-            }
+        &.search button[type=submit] {
+            width: auto;
+            height: 49px;
         }
     }
 }


### PR DESCRIPTION
Regression bug found by vitalkanev on the search page -the inline button was always visible instead of just in the scenario where javascript was disabled/unsupported. It also didn't look very well, so this fixes the look ever so slightly.

Bumps Demozoo to 1.1.1