### PR TITLE
Remove secondary edit buttons from non-logged-in users

### DIFF
--- a/bbs/templates/bbs/_tags.html
+++ b/bbs/templates/bbs/_tags.html
@@ -1,21 +1,9 @@
-<div class="editable_chunk panel tags_panel {% if site_is_writeable and user.is_authenticated %}edit_toggle{% endif %}">
+<div class="editable_chunk panel tags_panel {% if can_edit %}edit_toggle{% endif %}">
     <h3 class="panel__title">Tags</h3>
-
-    {% if site_is_writeable and not user.is_authenticated %}
-        {% comment %} Provide an 'edit' button that takes them to the login page.
-            For logged-in users, the 'edit' button will be added via JS
-            (because non-JS users will see the edit controls on the tags anyhow).
-        {% endcomment %}
-        <ul class="actions">
-            <li>
-                <a href="{% url 'log_in' %}?next={{ bbs.get_absolute_url|urlencode }}" class="action_button icon edit edit_chunk" rel="nofollow">Edit tags</a>
-            </li>
-        </ul>
-    {% endif %}
 
     <div id="tags_message"></div>
     {% include "bbs/_tags_list.html" with tags=tags only %}
-    {% if site_is_writeable and tags_form %}
+    {% if can_edit %}
         <form class="tags_form" action="{% url 'bbs_edit_tags' bbs.id %}" method="post">
             {% csrf_token %}
             {{ tags_form.tags }}

--- a/bbs/templates/bbs/_text_ads.html
+++ b/bbs/templates/bbs/_text_ads.html
@@ -1,6 +1,6 @@
 <div class="panel editable_chunk text_ads_panel">
     <h3 class="panel__title">Text ads</h3>
-    {% if site_is_writeable %}
+    {% if can_edit %}
         <ul class="actions">
             <li>
                 <a href="{% url 'bbs_edit_text_ads' bbs.id %}" class="action_button icon edit edit_chunk open_in_lightbox" rel="nofollow">Edit text ads</a>

--- a/bbs/templates/bbs/show.html
+++ b/bbs/templates/bbs/show.html
@@ -21,7 +21,7 @@
     <div class="editable_chunk">
         <div class="signpost">BBS</div>
 
-        {% if site_is_writeable %}
+        {% if prompt_to_edit %}
             <ul class="actions">
                 <li>
                     <a href="{% url 'edit_bbs' bbs.id %}" class="action_button icon edit edit_chunk open_in_lightbox" rel="nofollow">Edit</a>
@@ -55,20 +55,24 @@
 
     </div>
 
-    <div class="editable_chunk panel external_links_panel">
-        <h3 class="panel__title">External links</h3>
+    {% if external_links or can_edit %}
+        <div class="editable_chunk panel external_links_panel">
+            <h3 class="panel__title">External links</h3>
 
-        <ul class="actions">
-            <li>
-                <a href="{% url 'bbs_edit_external_links' bbs.id %}" class="action_button icon edit edit_chunk open_in_lightbox focus_empty_input" title="Edit external links" rel="nofollow">Edit</a>
-            </li>
-        </ul>
-        <ul class="external_links">
-            {% for link in external_links %}
-                <li>{{ link.html_link|safe }}</li>
-            {% endfor %}
-        </ul>
-    </div>
+            {% if can_edit %}
+                <ul class="actions">
+                    <li>
+                        <a href="{% url 'bbs_edit_external_links' bbs.id %}" class="action_button icon edit edit_chunk open_in_lightbox focus_empty_input" title="Edit external links" rel="nofollow">Edit</a>
+                    </li>
+                </ul>
+            {% endif %}
+            <ul class="external_links">
+                {% for link in external_links %}
+                    <li>{{ link.html_link|safe }}</li>
+                {% endfor %}
+            </ul>
+        </div>
+    {% endif %}
 
     {% if bbs.notes or request.user.is_staff %}
         <div class="editable_chunk panel notes_panel">
@@ -84,17 +88,8 @@
     {% endif %}
 
     <div id="side_column">
-        <div class="panel staff_panel editable_chunk {% if site_is_writeable and user.is_authenticated %}edit_toggle {% if editing_staff %}editing{% endif %}{% endif %}">
+        <div class="panel staff_panel editable_chunk {% if can_edit %}edit_toggle {% if editing_staff %}editing{% endif %}{% endif %}">
             <h3 class="panel__title">Staff</h3>
-
-            {% if site_is_writeable and not user.is_authenticated %}
-                {% comment %} Provide an 'edit' button that takes them to the login page{% endcomment %}
-                <ul class="actions">
-                    <li>
-                        <a href="{% url 'log_in' %}?next={{ bbs.get_absolute_url|urlencode }}" class="action_button icon edit edit_chunk" rel="nofollow">Edit</a>
-                    </li>
-                </ul>
-            {% endif %}
 
             <ul class="staff">
                 {% for operator in staff %}
@@ -102,7 +97,7 @@
                         <a href="{% url 'scener' operator.releaser.id %}" {% if not operator.is_current %}title="ex-staff"{% endif %}>{{ operator.releaser.name }}</a>
                         {% releaser_flag operator.releaser %}
                         - {{ operator.get_role_display }}
-                        {% if site_is_writeable and user.is_authenticated %}
+                        {% if can_edit %}
                             <a href="{% url 'bbs_edit_operator' bbs.id operator.id %}" class="open_in_lightbox edit_operator">
                                 <img src="/static/images/icons/edit.png" width="16" height="16" alt="Edit staff member" title="Edit staff member" />
                             </a>
@@ -110,29 +105,20 @@
                     </li>
                 {% endfor %}
             </ul>
-            {% if site_is_writeable and user.is_authenticated %}
+            {% if can_edit %}
                 <a href="{% url 'bbs_add_operator' bbs.id %}" class="action_button icon add open_in_lightbox add_operator">Add staff member</a>
             {% endif %}
         </div>
 
-        <div class="panel affiliations_panel editable_chunk {% if site_is_writeable and user.is_authenticated %}edit_toggle {% if editing_affiliations %}editing{% endif %}{% endif %}">
+        <div class="panel affiliations_panel editable_chunk {% if can_edit %}edit_toggle {% if editing_affiliations %}editing{% endif %}{% endif %}">
             <h3 class="panel__title">Affiliated with</h3>
-
-            {% if site_is_writeable and not user.is_authenticated %}
-                {% comment %} Provide an 'edit' button that takes them to the login page{% endcomment %}
-                <ul class="actions">
-                    <li>
-                        <a href="{% url 'log_in' %}?next={{ bbs.get_absolute_url|urlencode }}" class="action_button icon edit edit_chunk" rel="nofollow">Edit</a>
-                    </li>
-                </ul>
-            {% endif %}
 
             <ul class="affiliations">
                 {% for affiliation in affiliations %}
                     <li class="group">
                         <a href="{% url 'group' affiliation.group.id %}">{{ affiliation.group.name }}</a>
                         {% if affiliation.role %}- {{ affiliation.get_role_display }}{% endif %}
-                        {% if site_is_writeable and user.is_authenticated %}
+                        {% if can_edit %}
                             <a href="{% url 'bbs_edit_affiliation' bbs.id affiliation.id %}" class="open_in_lightbox edit_affiliation">
                                 <img src="/static/images/icons/edit.png" width="16" height="16" alt="Edit affiliation" title="Edit affiliation" />
                             </a>
@@ -140,25 +126,25 @@
                     </li>
                 {% endfor %}
             </ul>
-            {% if site_is_writeable and user.is_authenticated %}
+            {% if can_edit %}
                 <a href="{% url 'bbs_add_affiliation' bbs.id %}" class="action_button icon add open_in_lightbox add_affiliation">Add group</a>
             {% endif %}
         </div>
     </div>
     
     <div id="main_column">
-        {% if text_ads or user.is_authenticated %}
+        {% if text_ads or can_edit %}
             {% include "bbs/_text_ads.html" %}
         {% endif %}
 
         {% include "bbs/_tags.html" %}
 
-        {% if bbstros or user.is_authenticated %}
+        {% if bbstros or can_edit %}
             <div class="panel bbstros_panel editable_chunk">
                 <h3 class="panel__title">
                     Promoted in
                 </h3>
-                {% if site_is_writeable %}
+                {% if can_edit %}
                     <ul class="actions">
                         <li><a href="{% url 'bbs_edit_bbstros' bbs.id %}" class="action_button icon edit edit_chunk open_in_lightbox">Edit production list</a></li>
                     </ul>

--- a/bbs/tests/test_views.py
+++ b/bbs/tests/test_views.py
@@ -94,6 +94,11 @@ class TestEdit(TestCase):
         self.bbs = BBS.objects.get(name='StarPort')
         self.alt_name = self.bbs.alternative_names.first()
 
+    def test_not_logged_in(self):
+        self.client.logout()
+        response = self.client.get('/bbs/%d/edit/' % self.bbs.id)
+        self.assertRedirects(response, '/account/login/?next=/bbs/%d/' % self.bbs.id)
+
     def test_get(self):
         response = self.client.get('/bbs/%d/edit/' % self.bbs.id)
         self.assertEqual(response.status_code, 200)

--- a/bbs/views.py
+++ b/bbs/views.py
@@ -3,6 +3,7 @@ from urllib.parse import urlencode
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
+from django.contrib.auth.views import redirect_to_login
 from django.db.models import Value
 from django.db.models.functions import Concat, Lower
 from django.http import HttpResponseRedirect
@@ -120,8 +121,13 @@ def create(request):
 
 
 @writeable_site_required
-@login_required
 def edit(request, bbs_id):
+    if not request.user.is_authenticated:
+        # Instead of redirecting back to this edit form after login, redirect to the BBS page.
+        # This is because the edit button pointing here is the only one a non-logged-in user sees,
+        # so they may intend to edit something else on the BBS page.
+        return redirect_to_login(reverse('bbs', args=[bbs_id]))
+
     bbs = get_object_or_404(BBS, id=bbs_id)
 
     if request.method == 'POST':

--- a/bbs/views.py
+++ b/bbs/views.py
@@ -1,5 +1,6 @@
 from urllib.parse import urlencode
 
+from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
 from django.db.models import Value
@@ -74,6 +75,8 @@ def show(request, bbs_id):
 
     return render(request, 'bbs/show.html', {
         'bbs': bbs,
+        'prompt_to_edit': settings.SITE_IS_WRITEABLE,
+        'can_edit': settings.SITE_IS_WRITEABLE and request.user.is_authenticated,
         'alternative_names': bbs.alternative_names.all(),
         'bbstros': bbstros,
         'staff': staff,

--- a/demoscene/templates/groups/show.html
+++ b/demoscene/templates/groups/show.html
@@ -57,23 +57,14 @@
 
     {% with group.alternative_nicks as alternative_nicks %}
         {% if alternative_nicks %}
-            <div class="panel alternative_nicks_panel editable_chunk {% if prompt_to_edit and user.is_authenticated %}edit_toggle {% if editing_nicks %}editing{% endif %}{% endif %}">
+            <div class="panel alternative_nicks_panel editable_chunk {% if can_edit %}edit_toggle {% if editing_nicks %}editing{% endif %}{% endif %}">
                 <h3 class="panel__title">Also known as</h3>
-
-                {% if prompt_to_edit and not user.is_authenticated %}
-                    {% comment %} Provide an 'edit' button that takes them to the login page{% endcomment %}
-                    <ul class="actions">
-                        <li>
-                            <a href="{% url 'log_in' %}?next={{ group.get_absolute_url|urlencode }}" class="action_button icon edit edit_chunk" rel="nofollow">Edit</a>
-                        </li>
-                    </ul>
-                {% endif %}
 
                 <ul class="nicks">
                     {% for nick in alternative_nicks %}
                         <li>
                             <b>{{ nick.name }}</b> {% nick_variants nick %}
-                            {% if prompt_to_edit and user.is_authenticated %}
+                            {% if can_edit %}
                                 <a href="{% url 'releaser_edit_nick' group.id nick.id %}" class="open_in_lightbox edit_nick">
                                     <img src="/static/images/icons/edit.png" width="16" height="16" alt="Edit name" title="Edit name" />
                                 </a>
@@ -81,7 +72,7 @@
                         </li>
                     {% endfor %}
                 </ul>
-                {% if prompt_to_edit and user.is_authenticated %}
+                {% if can_edit %}
                     <a href="{% url 'releaser_add_nick' group.id %}" class="action_button icon add add_nick open_in_lightbox">Add another name</a>
                 {% endif %}
             </div>
@@ -90,7 +81,7 @@
 
     <div class="editable_chunk panel external_links_panel">
         <h3 class="panel__title">External links</h3>
-        {% if prompt_to_edit %}
+        {% if can_edit %}
             <ul class="actions">
                 <li>
                     <a href="{% url 'releaser_edit_external_links' group.id %}" class="action_button icon edit edit_chunk open_in_lightbox focus_empty_input" title="Edit external links" rel="nofollow">Edit</a>
@@ -132,24 +123,15 @@
             </div>
         {% endif %}
 
-        <div class="panel members_panel editable_chunk {% if prompt_to_edit and user.is_authenticated %}edit_toggle {% if editing_members %}editing{% endif %}{% endif %}">
+        <div class="panel members_panel editable_chunk {% if can_edit %}edit_toggle {% if editing_members %}editing{% endif %}{% endif %}">
             <h3 class="panel__title">Members</h3>
-
-            {% if prompt_to_edit and not user.is_authenticated %}
-                {% comment %} Provide an 'edit' button that takes them to the login page{% endcomment %}
-                <ul class="actions">
-                    <li>
-                        <a href="{% url 'log_in' %}?next={{ group.get_absolute_url|urlencode }}" class="action_button icon edit edit_chunk" rel="nofollow">Edit</a>
-                    </li>
-                </ul>
-            {% endif %}
 
             <ul class="memberships">
                 {% for membership in memberships %}
                     <li class="scener {% if not membership.is_current %}previous_membership{% endif %}">
                         <a href="{% url 'scener' membership.member.id %}" {% if not membership.is_current %}title="ex-member"{% endif %}>{{ membership.member.name }}</a>
                         {% releaser_flag membership.member %}
-                        {% if prompt_to_edit and user.is_authenticated %}
+                        {% if can_edit %}
                             <a href="{% url 'group_edit_membership' group.id membership.id %}" class="open_in_lightbox edit_membership">
                                 <img src="/static/images/icons/edit.png" width="16" height="16" alt="Edit membership" title="Edit membership" />
                             </a>
@@ -157,29 +139,20 @@
                     </li>
                 {% endfor %}
             </ul>
-            {% if prompt_to_edit and user.is_authenticated %}
+            {% if can_edit %}
                 <a href="{% url 'group_add_member' group.id %}" class="action_button icon add open_in_lightbox add_member">Add member</a>
             {% endif %}
         </div>
 
-        <div class="panel subgroups_panel editable_chunk {% if prompt_to_edit and user.is_authenticated %}edit_toggle {% if editing_subgroups %}editing{% endif %}{% endif %}">
+        <div class="panel subgroups_panel editable_chunk {% if can_edit %}edit_toggle {% if editing_subgroups %}editing{% endif %}{% endif %}">
             <h3 class="panel__title">Subgroups</h3>
-
-            {% if prompt_to_edit and not user.is_authenticated %}
-                {% comment %} Provide an 'edit' button that takes them to the login page{% endcomment %}
-                <ul class="actions">
-                    <li>
-                        <a href="{% url 'log_in' %}?next={{ group.get_absolute_url|urlencode }}" class="action_button icon edit edit_chunk" rel="nofollow">Edit</a>
-                    </li>
-                </ul>
-            {% endif %}
 
             <ul class="memberships">
                 {% for membership in subgroupships %}
                     <li class="group {% if not membership.is_current %}previous_membership{% endif %}">
                         <a href="{% url 'group' membership.member.id %}" {% if not membership.is_current %}title="ex-subgroup"{% endif %}>{{ membership.member.name }}</a>
                         {% releaser_flag membership.member %}
-                        {% if prompt_to_edit and user.is_authenticated %}
+                        {% if can_edit %}
                             <a href="{% url 'group_edit_subgroup' group.id membership.id %}" class="open_in_lightbox edit_subgroup">
                                 <img src="/static/images/icons/edit.png" width="16" height="16" alt="Edit subgroup" title="Edit subgroup" />
                             </a>
@@ -187,7 +160,7 @@
                     </li>
                 {% endfor %}
             </ul>
-            {% if prompt_to_edit and user.is_authenticated %}
+            {% if can_edit %}
                 <a href="{% url 'group_add_subgroup' group.id %}" class="action_button icon add open_in_lightbox add_subgroup">Add subgroup</a>
             {% endif %}
         </div>

--- a/demoscene/templates/sceners/show.html
+++ b/demoscene/templates/sceners/show.html
@@ -51,23 +51,14 @@
     </div>
 
     {% if alternative_nicks %}
-        <div class="panel alternative_nicks_panel editable_chunk {% if prompt_to_edit and user.is_authenticated %}edit_toggle {% if editing_nicks %}editing{% endif %}{% endif %}">
+        <div class="panel alternative_nicks_panel editable_chunk {% if can_edit %}edit_toggle {% if editing_nicks %}editing{% endif %}{% endif %}">
             <h3 class="panel__title">Also known as</h3>
-
-            {% if prompt_to_edit and not user.is_authenticated %}
-                {% comment %} Provide an 'edit' button that takes them to the login page{% endcomment %}
-                <ul class="actions">
-                    <li>
-                        <a href="{% url 'log_in' %}?next={{ scener.get_absolute_url|urlencode }}" class="action_button icon edit edit_chunk" rel="nofollow">Edit</a>
-                    </li>
-                </ul>
-            {% endif %}
 
             <ul class="nicks">
                 {% for nick in alternative_nicks %}
                     <li>
                         <b>{{ nick.name }}</b> {% nick_variants nick %}
-                        {% if prompt_to_edit and user.is_authenticated %}
+                        {% if can_edit %}
                             <a href="{% url 'releaser_edit_nick' scener.id nick.id %}" class="open_in_lightbox edit_nick">
                                 <img src="/static/images/icons/edit.png" width="16" height="16" alt="Edit name" title="Edit name" />
                             </a>
@@ -75,7 +66,7 @@
                     </li>
                 {% endfor %}
             </ul>
-            {% if prompt_to_edit and user.is_authenticated %}
+            {% if can_edit %}
                 <a href="{% url 'releaser_add_nick' scener.id %}" class="action_button icon add add_nick open_in_lightbox">Add another name</a>
             {% endif %}
         </div>
@@ -110,7 +101,7 @@
                     <img src="/static/images/icons/flags/{{ scener.country_code|lower }}.png" alt="" />
                 {% endif %}
             {% endif %}
-            {% if prompt_to_edit %}
+            {% if can_edit %}
                 <a href="{% url 'scener_edit_location' scener.id %}" class="open_in_lightbox" rel="nofollow">
                     <img src="/static/images/icons/edit.png" width="16" height="16" alt="Edit location" title="Edit location" />
                 </a>
@@ -122,7 +113,7 @@
     <div class="editable_chunk panel external_links_panel">
         <h3 class="panel__title">External links</h3>
 
-        {% if prompt_to_edit %}
+        {% if can_edit %}
             <ul class="actions">
                 <li>
                     <a href="{% url 'releaser_edit_external_links' scener.id %}" class="action_button icon edit edit_chunk open_in_lightbox focus_empty_input" title="Edit external links" rel="nofollow">Edit</a>
@@ -150,23 +141,14 @@
     {% endif %}
 
     <div id="side_column">
-        <div class="panel groups_panel editable_chunk {% if prompt_to_edit and user.is_authenticated %}edit_toggle {% if editing_groups %}editing{% endif %}{% endif %}">
+        <div class="panel groups_panel editable_chunk {% if can_edit %}edit_toggle {% if editing_groups %}editing{% endif %}{% endif %}">
             <h3 class="panel__title">Member of</h3>
-
-            {% if prompt_to_edit and not user.is_authenticated %}
-                {% comment %} Provide an 'edit' button that takes them to the login page{% endcomment %}
-                <ul class="actions">
-                    <li>
-                        <a href="{% url 'log_in' %}?next={{ scener.get_absolute_url|urlencode }}" class="action_button icon edit edit_chunk" rel="nofollow">Edit</a>
-                    </li>
-                </ul>
-            {% endif %}
 
             <ul class="memberships">
                 {% for membership in memberships %}
                     <li class="group {% if not membership.is_current %}previous_membership{% endif %}">
                         <a href="{% url 'group' membership.group.id %}" {% if not membership.is_current %}title="previous membership"{% endif %}>{{ membership.group.name }}</a>
-                        {% if prompt_to_edit and user.is_authenticated %}
+                        {% if can_edit %}
                             <a href="{% url 'scener_edit_membership' scener.id membership.id %}" class="open_in_lightbox edit_membership">
                                 <img src="/static/images/icons/edit.png" width="16" height="16" alt="Edit membership" title="Edit membership" />
                             </a>
@@ -174,7 +156,7 @@
                     </li>
                 {% endfor %}
             </ul>
-            {% if prompt_to_edit and user.is_authenticated %}
+            {% if can_edit %}
                 <a href="{% url 'scener_add_group' scener.id %}" class="action_button icon add open_in_lightbox add_group">Add group</a>
             {% endif %}
         </div>

--- a/demoscene/templatetags/releaser_tags.py
+++ b/demoscene/templatetags/releaser_tags.py
@@ -64,5 +64,5 @@ def combined_releases(context, releaser):
     return {
         'releaser': releaser,
         'credits': credits_with_prods_and_screenshots,
-        'prompt_to_edit': context.get('prompt_to_edit', False),
+        'can_edit': context.get('can_edit', False),
     }

--- a/demoscene/tests/test_releaser_views.py
+++ b/demoscene/tests/test_releaser_views.py
@@ -222,6 +222,11 @@ class TestEditPrimaryNick(TestCase):
         self.gasman = Releaser.objects.get(name='Gasman')
         self.papaya_dezign = Releaser.objects.get(name='Papaya Dezign')
 
+    def test_not_logged_in(self):
+        self.client.logout()
+        response = self.client.get('/releasers/%d/edit_primary_nick/' % self.gasman.id)
+        self.assertRedirects(response, '/account/login/?next=/sceners/%d/' % self.gasman.id)
+
     def test_locked(self):
         response = self.client.get('/releasers/%d/edit_primary_nick/' % self.papaya_dezign.id)
         self.assertEqual(response.status_code, 403)

--- a/demoscene/views/groups.py
+++ b/demoscene/views/groups.py
@@ -43,6 +43,9 @@ def show(request, group_id):
         'bbs__name'
     )
 
+    prompt_to_edit = settings.SITE_IS_WRITEABLE and (request.user.is_staff or not group.locked)
+    can_edit = prompt_to_edit and request.user.is_authenticated
+
     return render(request, 'groups/show.html', {
         'group': group,
         'editing_nicks': (request.GET.get('editing') == 'nicks'),
@@ -70,7 +73,8 @@ def show(request, group_id):
             ).order_by('-release_date_date', 'release_date_precision', '-sortable_title')
         ),
         'external_links': external_links,
-        'prompt_to_edit': settings.SITE_IS_WRITEABLE and (request.user.is_staff or not group.locked),
+        'prompt_to_edit': prompt_to_edit,
+        'can_edit': can_edit,
         'show_locked_button': request.user.is_authenticated and group.locked,
         'show_lock_button': request.user.is_staff and settings.SITE_IS_WRITEABLE and not group.locked,
     })

--- a/demoscene/views/releasers.py
+++ b/demoscene/views/releasers.py
@@ -2,6 +2,7 @@ import datetime
 
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
+from django.contrib.auth.views import redirect_to_login
 from django.core.exceptions import PermissionDenied
 from django.http import HttpResponseRedirect
 from django.shortcuts import get_object_or_404, render
@@ -255,9 +256,13 @@ def add_nick(request, releaser_id):
 
 
 @writeable_site_required
-@login_required
 def edit_primary_nick(request, releaser_id):
     releaser = get_object_or_404(Releaser, id=releaser_id)
+    if not request.user.is_authenticated:
+        # Instead of redirecting back to this edit form after login, redirect to the releaser page.
+        # This is because the edit button pointing here is the only one a non-logged-in user sees,
+        # so they may intend to edit something else on the releaser page.
+        return redirect_to_login(releaser.get_absolute_url())
 
     if not releaser.editable_by_user(request.user):
         raise PermissionDenied

--- a/demoscene/views/sceners.py
+++ b/demoscene/views/sceners.py
@@ -53,6 +53,9 @@ def show(request, scener_id, edit_mode=False):
         .order_by('-is_current', '-role', 'bbs__name')
     )
 
+    prompt_to_edit = settings.SITE_IS_WRITEABLE and (request.user.is_staff or not scener.locked)
+    can_edit = prompt_to_edit and request.user.is_authenticated
+
     return render(request, 'sceners/show.html', {
         'scener': scener,
         'alternative_nicks': scener.alternative_nicks.prefetch_related('variants'),
@@ -67,6 +70,7 @@ def show(request, scener_id, edit_mode=False):
         'bbses_operated': bbses_operated,
         'can_edit_real_names': can_edit_real_names,
         'prompt_to_edit': settings.SITE_IS_WRITEABLE and (request.user.is_staff or not scener.locked),
+        'can_edit': can_edit,
         'show_locked_button': request.user.is_authenticated and scener.locked,
         'show_lock_button': request.user.is_staff and settings.SITE_IS_WRITEABLE and not scener.locked,
     })

--- a/demozoo/templates/shared/credited_production_listing.html
+++ b/demozoo/templates/shared/credited_production_listing.html
@@ -2,7 +2,7 @@
 
 <div class="panel editable_chunk">
     <h3 class="panel__title productions_header">Productions ({{ credits|length }})</h3>
-    {% if prompt_to_edit %}
+    {% if can_edit %}
         <ul class="actions">
             <li>
                 <a href="{% url 'new_production' %}?releaser_id={{ releaser.id }}" class="action_button icon add open_in_lightbox edit_chunk" rel="nofollow">Add production</a>

--- a/parties/templates/parties/show.html
+++ b/parties/templates/parties/show.html
@@ -92,7 +92,7 @@
     <div class="editable_chunk party_core_details">
         <div class="signpost">Party</div>
 
-        {% if site_is_writeable %}
+        {% if prompt_to_edit %}
             <ul class="actions">
                 <li>
                     <a href="{% url 'edit_party' party.id %}" class="action_button icon edit edit_chunk open_in_lightbox" title="Edit party details">Edit</a>
@@ -135,16 +135,8 @@
         </ul>
     </div>
 
-    <div class="editable_chunk panel organisers_panel {% if site_is_writeable and user.is_authenticated %}edit_toggle {% if editing_organisers %}editing{% endif %}{% endif %}">
+    <div class="editable_chunk panel organisers_panel {% if can_edit %}edit_toggle {% if editing_organisers %}editing{% endif %}{% endif %}">
         <h3 class="panel__title">Organisers</h3>
-        {% if site_is_writeable and not user.is_authenticated %}
-            {% comment %} Provide an 'edit' button that takes them to the login page{% endcomment %}
-            <ul class="actions">
-                <li>
-                    <a href="{% url 'log_in' %}?next={{ party.get_absolute_url|urlencode }}" class="action_button icon edit edit_chunk" rel="nofollow">Edit</a>
-                </li>
-            </ul>
-        {% endif %}
 
         {% regroup organisers by releaser.is_group as orga_type_list %}
         {% for is_group, orga_list in orga_type_list %}
@@ -156,7 +148,7 @@
                         <li class="group">
                             <a href="{% url 'group' organiser.releaser.id %}">{{ organiser.releaser.name }}</a>
                             {% if organiser.role %}({{ organiser.role}}){% endif %}
-                            {% if site_is_writeable and user.is_authenticated %}
+                            {% if can_edit %}
                                 <a href="{% url 'party_edit_organiser' party.id organiser.id %}" class="open_in_lightbox edit_organiser">
                                     <img src="/static/images/icons/edit.png" width="16" height="16" alt="Edit organiser" title="Edit organiser" />
                                 </a>
@@ -171,7 +163,7 @@
                             <a href="{% url 'scener' organiser.releaser.id %}">{{ organiser.releaser.name }}</a>
                             {% releaser_flag organiser.releaser %}
                             {% if organiser.role %}({{ organiser.role}}){% endif %}
-                            {% if site_is_writeable and user.is_authenticated %}
+                            {% if can_edit %}
                                 <a href="{% url 'party_edit_organiser' party.id organiser.id %}" class="open_in_lightbox edit_organiser">
                                     <img src="/static/images/icons/edit.png" width="16" height="16" alt="Edit organiser" title="Edit organiser" />
                                 </a>
@@ -181,7 +173,7 @@
                 </ul>
             {% endif %}
         {% endfor %}
-        {% if site_is_writeable and user.is_authenticated %}
+        {% if can_edit %}
             <div class="add_organiser">
                 <a href="{% url 'party_add_organiser' party.id %}" class="action_button icon add open_in_lightbox">Add organiser</a>
             </div>
@@ -199,21 +191,23 @@
         </div>
     {% endif %}
 
-    <div class="editable_chunk panel external_links_panel">
-        <h3 class="panel__title">External links</h3>
-        {% if site_is_writeable %}
-            <ul class="actions">
-                <li>
-                    <a href="{% url 'party_edit_external_links' party.id %}" class="action_button icon edit edit_chunk open_in_lightbox focus_empty_input" title="Edit external links">Edit</a>
-                </li>
+    {% if external_links or can_edit %}
+        <div class="editable_chunk panel external_links_panel">
+            <h3 class="panel__title">External links</h3>
+            {% if can_edit %}
+                <ul class="actions">
+                    <li>
+                        <a href="{% url 'party_edit_external_links' party.id %}" class="action_button icon edit edit_chunk open_in_lightbox focus_empty_input" title="Edit external links">Edit</a>
+                    </li>
+                </ul>
+            {% endif %}
+            <ul class="external_links">
+                {% for link in external_links %}
+                    <li>{{ link.html_link|safe }}</li>
+                {% endfor %}
             </ul>
-        {% endif %}
-        <ul class="external_links">
-            {% for link in external_links %}
-                <li>{{ link.html_link|safe }}</li>
-            {% endfor %}
-        </ul>
-    </div>
+        </div>
+    {% endif %}
 
     {% if parties_in_series.count > 1 %}
         <div class="parties_in_series">
@@ -249,12 +243,12 @@
         </div>
     {% endif %}
 
-    {% if invitations or user.is_authenticated %}
+    {% if invitations or can_edit %}
         <div class="panel invitations_panel editable_chunk">
             <h3 class="panel__title">
                 Invitation{{ invitations|length|pluralize }}
             </h3>
-            {% if site_is_writeable %}
+            {% if can_edit %}
                 <ul class="actions">
                     <li><a href="{% url 'party_edit_invitations' party.id %}" class="action_button icon edit edit_chunk open_in_lightbox">Edit invitations</a></li>
                 </ul>
@@ -266,10 +260,10 @@
         </div>
     {% endif %}
 
-    {% if releases or user.is_authenticated %}
+    {% if releases or can_edit %}
         <div class="panel releases_panel editable_chunk">
             <h3 class="panel__title">Releases</h3>
-            {% if site_is_writeable %}
+            {% if can_edit %}
                 <ul class="actions">
                     <li><a href="{% url 'party_edit_releases' party.id %}" class="action_button icon edit edit_chunk open_in_lightbox">Edit releases</a></li>
                 </ul>
@@ -281,7 +275,7 @@
         </div>
     {% endif %}
 
-    {% if competitions_with_placings_and_screenshots or user.is_authenticated %}
+    {% if competitions_with_placings_and_screenshots or can_edit %}
         <div class="panel results_panel">
             <div class="results_menu_column">
                 <div class="results_menu">
@@ -300,7 +294,7 @@
                 {% for compo, placings in competitions_with_placings_and_screenshots %}
                     <section class="competition editable_chunk" id="competition_{{ compo.id }}">
 
-                        {% if site_is_writeable %}
+                        {% if can_edit %}
                             <ul class="actions">
                                 <li><a class="action_button icon edit edit_chunk" href="{% url 'competition_edit' compo.id %}">Edit competition</a></li>
                                 {% if request.user.is_staff and not placings %}
@@ -317,7 +311,7 @@
                     </section>
                 {% endfor %}
 
-                {% if site_is_writeable %}
+                {% if can_edit %}
                     <ul class="actions">
                         <li>
                             <a class="action_button icon add open_in_lightbox" href="{% url 'party_add_competition' party.id %}">Add competition</a>

--- a/parties/templates/parties/show_series.html
+++ b/parties/templates/parties/show_series.html
@@ -68,7 +68,7 @@
         </div>
     {% endif %}
 
-    {% if site_is_writeable %}
+    {% if site_is_writeable and request.user.is_authenticated %}
         <ul class="actions">
             <li><a href="{% url 'new_party' %}?party_series_name={{ party_series.name|urlencode }}" class="action_button icon add open_in_lightbox">New party edition</a></li>
         </ul>

--- a/parties/tests/test_party_views.py
+++ b/parties/tests/test_party_views.py
@@ -178,6 +178,11 @@ class TestEditParty(TestCase):
         self.client.login(username='testuser', password='12345')
         self.party = Party.objects.get(name='Forever 2e3')
 
+    def test_not_logged_in(self):
+        self.client.logout()
+        response = self.client.get('/parties/%d/edit/' % self.party.id)
+        self.assertRedirects(response, '/account/login/?next=/parties/%d/' % self.party.id)
+
     def test_get(self):
         response = self.client.get('/parties/%d/edit/' % self.party.id)
         self.assertEqual(response.status_code, 200)

--- a/parties/views/parties.py
+++ b/parties/views/parties.py
@@ -5,6 +5,7 @@ from urllib.parse import urlencode
 
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
+from django.contrib.auth.views import redirect_to_login
 from django.conf import settings
 from django.core.exceptions import PermissionDenied
 from django.db.models import Prefetch
@@ -187,8 +188,13 @@ def create(request):
 
 
 @writeable_site_required
-@login_required
 def edit(request, party_id):
+    if not request.user.is_authenticated:
+        # Instead of redirecting back to this edit form after login, redirect to the party page.
+        # This is because the edit button pointing here is the only one a non-logged-in user sees,
+        # so they may intend to edit something else on the party page.
+        return redirect_to_login(reverse('party', args=[party_id]))
+
     party = get_object_or_404(Party, id=party_id)
     if request.method == 'POST':
         form = EditPartyForm(request.POST, instance=party, initial={

--- a/parties/views/parties.py
+++ b/parties/views/parties.py
@@ -5,6 +5,7 @@ from urllib.parse import urlencode
 
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
+from django.conf import settings
 from django.core.exceptions import PermissionDenied
 from django.db.models import Prefetch
 from django.db.models.functions import Lower
@@ -129,6 +130,8 @@ def show(request, party_id):
         ),
         'external_links': external_links,
         'comment_form': comment_form,
+        'prompt_to_edit': settings.SITE_IS_WRITEABLE,
+        'can_edit': settings.SITE_IS_WRITEABLE and request.user.is_authenticated,
     })
 
 

--- a/productions/carousel.py
+++ b/productions/carousel.py
@@ -234,7 +234,7 @@ class Carousel(object):
             # always show the 'add screenshot' / 'add artwork' button, except for the special case
             # that supertype is graphics or production and there are no carousel slides -
             # in which case the 'add a screenshot' call-to-action will be in the carousel area instead
-            show_add_screenshot_link = self.slides or self.production.supertype == 'music'
+            show_add_screenshot_link = self.user.is_authenticated and (self.slides or self.production.supertype == 'music')
             show_manage_screenshots_link = screenshots and self.user.is_staff
         else:
             show_add_screenshot_link = False

--- a/productions/templates/productions/_award_recommendations.html
+++ b/productions/templates/productions/_award_recommendations.html
@@ -1,6 +1,6 @@
 {% for event, recommendation_options in awards_accepting_recommendations %}
 <div class="award-recommendation">
-    {% if request.user.is_authenticated %}
+    {% if request.user.is_authenticated and site_is_writeable %}
         <header class="award-recommendation__header">
             <h2 class="award-recommendation__heading">
                 Recommend this production for <span class="award-recommendation__name">{{ event.name }}</span>!

--- a/productions/templates/productions/_credits.html
+++ b/productions/templates/productions/_credits.html
@@ -1,17 +1,5 @@
-<div class="editable_chunk credits_panel panel {% if not credits %}hidden{% endif %} {% if prompt_to_edit and user.is_authenticated %}edit_toggle {% if editing_credits %}editing{% endif %}{% endif %}" id="credits_panel">
+<div class="editable_chunk credits_panel panel {% if not credits %}hidden{% endif %} {% if can_edit %}edit_toggle {% if editing_credits %}editing{% endif %}{% endif %}" id="credits_panel">
     <h3 class="panel__title">Credits</h3>
-
-    {% if prompt_to_edit and not user.is_authenticated %}
-        {% comment %} Provide an 'edit' button that takes them to the login page.
-            For logged-in users, the 'edit' button will be added via JS
-            (because non-JS users will see the edit controls on the tags anyhow).
-        {% endcomment %}
-        <ul class="actions">
-            <li>
-                <a href="{% url 'log_in' %}?next={{ production.get_absolute_url|urlencode }}" class="action_button icon edit edit_chunk" title="Edit credits" rel="nofollow">Edit</a>
-            </li>
-        </ul>
-    {% endif %}
 
     <ul class="credits">
         {% regroup credits by nick as nick_list %}
@@ -23,7 +11,7 @@
                     {{ credit.description }}{% if not forloop.last %},{% endif %}
                 {% endfor %}
 
-                {% if prompt_to_edit and user.is_authenticated %}
+                {% if can_edit %}
                     <a href="{% url 'production_edit_credit' production.id nick_credits.grouper.id %}" class="edit_credit">
                         <img src="/static/images/icons/edit.png" width="16" height="16" alt="Edit credit" title="Edit credit" />
                     </a>
@@ -31,7 +19,7 @@
             </li>
         {% endfor %}
     </ul>
-    {% if prompt_to_edit and user.is_authenticated %}
+    {% if can_edit %}
         <a href="{% url 'production_add_credit' production.id %}" class="action_button icon add add_credit">Add credit</a>
     {% endif %}
 </div>

--- a/productions/templates/productions/_downloads.html
+++ b/productions/templates/productions/_downloads.html
@@ -1,6 +1,6 @@
 <div class="editable_chunk panel downloads_panel">
     <h3 class="panel__title">Downloads</h3>
-    {% if prompt_to_edit %}
+    {% if can_edit %}
         <ul class="actions">
             <li>
                 <a href="{% url 'production_edit_download_links' production.id %}" class="action_button icon edit edit_chunk open_in_lightbox focus_empty_input" title="Edit download links" rel="nofollow">Edit</a>

--- a/productions/templates/productions/_external_links.html
+++ b/productions/templates/productions/_external_links.html
@@ -1,6 +1,6 @@
 <div class="editable_chunk panel external_links_panel">
     <h3 class="panel__title">External links</h3>
-    {% if prompt_to_edit %}
+    {% if can_edit %}
         <ul class="actions">
             <li>
                 <a href="{% url 'production_edit_external_links' production.id %}" class="action_button icon edit edit_chunk open_in_lightbox focus_empty_input" title="Edit external links" rel="nofollow">Edit</a>

--- a/productions/templates/productions/_info_files.html
+++ b/productions/templates/productions/_info_files.html
@@ -1,6 +1,6 @@
 <div class="panel editable_chunk info_files_panel">
     <h3 class="panel__title">Info file{{ info_files|length|pluralize }}</h3>
-    {% if prompt_to_edit %}
+    {% if can_edit %}
         <ul class="actions">
             <li>
                 <a href="{% url 'production_edit_info_files' production.id %}" class="action_button icon edit edit_chunk open_in_lightbox" title="Edit info files" rel="nofollow">Edit</a>

--- a/productions/templates/productions/_notes.html
+++ b/productions/templates/productions/_notes.html
@@ -1,6 +1,5 @@
 {% load safe_markdown %}
 
-
 {% if production.notes or request.user.is_staff %}
     <div class="editable_chunk panel notes_panel">
         {% if request.user.is_staff and site_is_writeable %}

--- a/productions/templates/productions/_tags.html
+++ b/productions/templates/productions/_tags.html
@@ -1,25 +1,15 @@
-<div class="editable_chunk panel tags_panel {% if prompt_to_edit and user.is_authenticated %}edit_toggle{% endif %}">
-    <h3 class="panel__title">Tags</h3>
+{% if tags or can_edit %}
+    <div class="editable_chunk panel tags_panel {% if can_edit %}edit_toggle{% endif %}">
+        <h3 class="panel__title">Tags</h3>
 
-    {% if prompt_to_edit and not user.is_authenticated %}
-        {% comment %} Provide an 'edit' button that takes them to the login page.
-            For logged-in users, the 'edit' button will be added via JS
-            (because non-JS users will see the edit controls on the tags anyhow).
-        {% endcomment %}
-        <ul class="actions">
-            <li>
-                <a href="{% url 'log_in' %}?next={{ production.get_absolute_url|urlencode }}" class="action_button icon edit edit_chunk" title="Edit tags" rel="nofollow">Edit</a>
-            </li>
-        </ul>
-    {% endif %}
-
-    <div id="tags_message"></div>
-    {% include "productions/_tags_list.html" with tags=tags only %}
-    {% if prompt_to_edit and tags_form %}
-        <form class="tags_form" action="{% url 'production_edit_tags' production.id %}" method="post">
-            {% csrf_token %}
-            {{ tags_form.tags }}
-            <input type="submit" value="Update" />
-        </form>
-    {% endif %}
-</div>
+        <div id="tags_message"></div>
+        {% include "productions/_tags_list.html" with tags=tags only %}
+        {% if can_edit %}
+            <form class="tags_form" action="{% url 'production_edit_tags' production.id %}" method="post">
+                {% csrf_token %}
+                {{ tags_form.tags }}
+                <input type="submit" value="Update" />
+            </form>
+        {% endif %}
+    </div>
+{% endif %}

--- a/productions/templates/productions/show.html
+++ b/productions/templates/productions/show.html
@@ -79,35 +79,29 @@
 
             {% include "productions/_tags.html" %}
 
-            {% if prompt_to_edit %}
+            {% if can_edit %}
                 <div class="panel tell_us_something_panel">
                     <p>Know something about this production that we don't?</p>
 
                     <div class="tell_us_something">
-                        {% if user.is_authenticated %}
-                            <div class="tell_us_something_title">Add other information</div>
-                            <ul class="tell_us_something_options">
-                                <li><a href="{% url 'production_edit_download_links' production.id %}" class="open_in_lightbox focus_empty_input">Add a download link</a></li>
-                                <li><a href="{% url 'production_edit_external_links' production.id %}" class="open_in_lightbox focus_empty_input">Add an external site link</a></li>
-                                {% if production.supertype == 'music' %}
-                                    <li><a href="{{ production.get_add_screenshot_url }}" class="open_in_lightbox">Add artwork</a></li>
-                                {% else %}
-                                    <li><a href="{{ production.get_add_screenshot_url }}" class="open_in_lightbox">Add a screenshot</a></li>
-                                {% endif %}
-                                <li><a href="{% url 'production_add_credit' production.id %}" class="add_credit">Add a credit</a></li>
-                                <li><a href="{% url 'production_edit_info_files' production.id %}" class="open_in_lightbox">Add an info file</a></li>
-                                {% if production.can_have_soundtracks %}
-                                    <li><a href="{% url 'production_edit_soundtracks' production.id %}" class="open_in_lightbox">Add a soundtrack listing</a></li>
-                                {% endif %}
-                                {% if request.user.is_staff and not blurbs %}
-                                    <li><a href="{% url 'production_add_blurb' production.id %}" class="open_in_lightbox">Add a 'blurb'</a></li>
-                                {% endif %}
-                            </ul>
-                        {% else %}
-                            <div class="tell_us_something_title">
-                                <a href="{% url 'log_in' %}?next={{ production.get_absolute_url|urlencode }}" rel="nofollow">Tell us something!</a>
-                            </div>
-                        {% endif %}
+                        <div class="tell_us_something_title">Add other information</div>
+                        <ul class="tell_us_something_options">
+                            <li><a href="{% url 'production_edit_download_links' production.id %}" class="open_in_lightbox focus_empty_input">Add a download link</a></li>
+                            <li><a href="{% url 'production_edit_external_links' production.id %}" class="open_in_lightbox focus_empty_input">Add an external site link</a></li>
+                            {% if production.supertype == 'music' %}
+                                <li><a href="{{ production.get_add_screenshot_url }}" class="open_in_lightbox">Add artwork</a></li>
+                            {% else %}
+                                <li><a href="{{ production.get_add_screenshot_url }}" class="open_in_lightbox">Add a screenshot</a></li>
+                            {% endif %}
+                            <li><a href="{% url 'production_add_credit' production.id %}" class="add_credit">Add a credit</a></li>
+                            <li><a href="{% url 'production_edit_info_files' production.id %}" class="open_in_lightbox">Add an info file</a></li>
+                            {% if production.can_have_soundtracks %}
+                                <li><a href="{% url 'production_edit_soundtracks' production.id %}" class="open_in_lightbox">Add a soundtrack listing</a></li>
+                            {% endif %}
+                            {% if request.user.is_staff and not blurbs %}
+                                <li><a href="{% url 'production_add_blurb' production.id %}" class="open_in_lightbox">Add a 'blurb'</a></li>
+                            {% endif %}
+                        </ul>
                     </div>
                 </div>
             {% endif %}
@@ -125,7 +119,7 @@
             <div class="pack_contents_panel panel editable_chunk">
                 <h3 class="panel__title">Pack contents</h3>
 
-                {% if prompt_to_edit %}
+                {% if can_edit %}
                     <ul class="actions">
                         <li>
                             <a href="{% url 'production_edit_pack_contents' production.id %}" class="action_button icon edit edit_chunk open_in_lightbox" title="Edit pack contents" rel="nofollow">Edit</a>
@@ -155,7 +149,7 @@
             <div class="soundtracks_panel panel editable_chunk">
                 <h3 class="panel__title">Soundtrack</h3>
 
-                {% if prompt_to_edit %}
+                {% if can_edit %}
                     <ul class="actions">
                         <li>
                             <a href="{% url 'production_edit_soundtracks' production.id %}" class="action_button icon edit edit_chunk open_in_lightbox" title="Edit soundtrack details" rel="nofollow">Edit</a>

--- a/productions/tests/test_production_views.py
+++ b/productions/tests/test_production_views.py
@@ -364,6 +364,12 @@ class TestEditCoreDetails(TestCase):
         User.objects.create_user(username='testuser', password='12345')
         self.client.login(username='testuser', password='12345')
 
+    def test_not_logged_in(self):
+        self.client.logout()
+        pondlife = Production.objects.get(title='Pondlife')
+        response = self.client.get('/productions/%d/edit_core_details/' % pondlife.id)
+        self.assertRedirects(response, '/account/login/?next=/productions/%d/' % pondlife.id)
+
     def test_locked(self):
         mooncheese = Production.objects.get(title='Mooncheese')
         response = self.client.get('/productions/%d/edit_core_details/' % mooncheese.id)

--- a/productions/views/generic.py
+++ b/productions/views/generic.py
@@ -114,9 +114,13 @@ class ShowView(View):
         except IndexError:
             meta_screenshot = None
 
+        prompt_to_edit = settings.SITE_IS_WRITEABLE and (self.request.user.is_staff or not self.production.locked)
+        can_edit = prompt_to_edit and self.request.user.is_authenticated
+
         return {
             'production': self.production,
-            'prompt_to_edit': settings.SITE_IS_WRITEABLE and (self.request.user.is_staff or not self.production.locked),
+            'prompt_to_edit': prompt_to_edit,
+            'can_edit': can_edit,
             'download_links': self.production.download_links,
             'external_links': self.production.external_links,
             'info_files': self.production.info_files.all(),


### PR DESCRIPTION
Following our plan to reduce the UI clutter of edit buttons: hide them all from non-logged-in users, except for one at the top.

Currently only implemented on the production page - others to follow.