### PR TITLE
Disambiguate "size"

### DIFF
--- a/productions/templates/productions/add_artwork.html
+++ b/productions/templates/productions/add_artwork.html
@@ -19,7 +19,7 @@
     <div class="long_help">
         <h3>Guidelines</h3>
         <ul>
-            <li>Upload artwork at the highest resolution available - we don't impose size limits</li>
+            <li>Upload artwork at the highest resolution available - we don't impose limits on resolution - just keep the file-size below 10MB</li>
             <li>Upload as many images as appropriate - don't combine them into 'posters' or animations</li>
         </ul>
         <p style="text-align: right;">Thanks for brightening up our pages!</p>

--- a/productions/templates/productions/add_screenshot.html
+++ b/productions/templates/productions/add_screenshot.html
@@ -19,7 +19,7 @@
     <div class="long_help">
         <h3>Guidelines</h3>
         <ul>
-            <li>Create screenshots at the highest resolution available - we don't impose size limits</li>
+            <li>Create screenshots at the highest resolution available - we don't impose limits on resolution - just keep the file-size below 10MB</li>
             <li>Upload as many images as appropriate - don't combine them into 'posters' or animations</li>
             <li><strong>Don't upload screenshots from other sites</strong> (unless you made them yourself, and they follow the guidelines above)</li>
         </ul>


### PR DESCRIPTION
I just tried to upload a screenshot of around 14MB and got a `413 Payload Too Large` response. When uploading screenshots and artwork, the current wording is:

> Create screenshots at the highest resolution available - we don't impose size limits

The word "size" here is imho a bit ambiguous. This PR changes that to "resolution" and adds a note to keep the file size below 10MB (or whatever the current maximum file size limit is set to in the HTTP server). 