### PR TITLE
WIP: support ID/URL lookups in NickField

### DIFF
--- a/demoscene/views/nicks.py
+++ b/demoscene/views/nicks.py
@@ -31,7 +31,7 @@ def match(request):
     else:
         query = initial_query
 
-    nick_search = NickSearch(query.strip(), **filters)
+    nick_search = NickSearch(query.strip(), id_lookup=True, **filters)
 
     data = {
         'query': query,

--- a/lib/nick_field.py
+++ b/lib/nick_field.py
@@ -33,7 +33,8 @@ class NickLookup():
             search_term,
             sceners_only=sceners_only,
             groups_only=groups_only,
-            group_ids=group_ids
+            group_ids=group_ids,
+            id_lookup=True
         )
         self.matched_nick_field = MatchedNickField(nick_search, required=False)
 


### PR DESCRIPTION
Ref #375. #595 implemented lookups by ID/URL for productions (for soundtracks, pack contents, BBStros, party non-compo releases) - this is the corresponding update for nick lookups (for credits).

The actual selection seems to work (even if it's currently a bit clunky because it only triggers the lookup on typing something, not pasting), but submitting the form seems to treat it as an empty input, probably because the POST action does another nick lookup and that one doesn't have the id_lookup flag.