### PR TITLE
Remove nodejs steps from docker config

### DIFF
--- a/.docker/web/Dockerfile
+++ b/.docker/web/Dockerfile
@@ -6,17 +6,17 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends iputils-ping && \
     rm -rf /var/lib/apt/lists/*
 
-RUN curl -sL https://deb.nodesource.com/setup_18.x | bash - && \
-    apt-get install -y nodejs && \
-    npm install -g npm@latest
+# RUN curl -sL https://deb.nodesource.com/setup_18.x | bash - && \
+#     apt-get install -y nodejs && \
+#     npm install -g npm@latest
 
 COPY requirements.txt ./
 RUN pip install -r requirements.txt && rm requirements.txt
 
 COPY ./.docker/web/local.py ./demozoo/settings/local.py
 
-COPY package*.json ./
-RUN npm install --no-save
+# COPY package*.json ./
+# RUN npm install --no-save
 
 EXPOSE 8000
 

--- a/.docker/web/Dockerfile
+++ b/.docker/web/Dockerfile
@@ -6,9 +6,6 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends iputils-ping && \
     rm -rf /var/lib/apt/lists/*
 
-# RUN curl -sL https://deb.nodesource.com/setup_18.x | bash - && \
-#     apt-get install -y nodejs && \
-#     npm install -g npm@latest
 
 COPY requirements.txt ./
 RUN pip install -r requirements.txt && rm requirements.txt

--- a/.docker/web/Dockerfile
+++ b/.docker/web/Dockerfile
@@ -12,8 +12,6 @@ RUN pip install -r requirements.txt && rm requirements.txt
 
 COPY ./.docker/web/local.py ./demozoo/settings/local.py
 
-# COPY package*.json ./
-# RUN npm install --no-save
 
 EXPOSE 8000
 

--- a/.docker/web/entrypoint
+++ b/.docker/web/entrypoint
@@ -15,9 +15,6 @@ do
   sleep 5
 done
 
-# mkdir -p ./static_built/images
-# npm run build
-# npm run watch &
 
 echo "Running the server on http://localhost:8000"
 

--- a/.docker/web/entrypoint
+++ b/.docker/web/entrypoint
@@ -15,9 +15,9 @@ do
   sleep 5
 done
 
-mkdir -p ./static_built/images
-npm run build
-npm run watch &
+# mkdir -p ./static_built/images
+# npm run build
+# npm run watch &
 
 echo "Running the server on http://localhost:8000"
 


### PR DESCRIPTION
This PR removes nodejs/npm steps in the demozoo-web container config. 

They aren't functionally doing what they're supposed to be doing and cause confusion about the completeness of this step.

Right now the workaround for running the CSS/SVG build steps when using Docker is to run these steps on the host system.