### PR TITLE
Recognize Plus4World Profile links

### DIFF
--- a/demoscene/utils/groklinks.py
+++ b/demoscene/utils/groklinks.py
@@ -1548,6 +1548,11 @@ class Plus4WorldMember(UrlPattern):
     pattern = "/members/<slug>"
 
 
+class Plus4WorldProfile(UrlPattern):
+    site = plus4world
+    pattern = "/profile/<slug>"
+    
+
 class Plus4WorldCompo(UrlPattern):
     site = plus4world
     pattern = "/compos/<int>"
@@ -1808,7 +1813,7 @@ RELEASER_LINK_TYPES = [
     HallOfLightArtist, SpotifyArtist, KestraBitworldAuthor,
     GithubAccount, GithubRepo, AtarimaniaPage, GameboyDemospottingAuthor, PixeljointArtist,
     ZxArtAuthor, ZxTunesArtist, InternetArchivePage,
-    Plus4WorldGroup, Plus4WorldMember, BandcampArtist, VimeoUser, SpeccyPlAuthor, AtarikiEntry,
+    Plus4WorldGroup, Plus4WorldMember, Plus4WorldProfile, BandcampArtist, VimeoUser, SpeccyPlAuthor, AtarikiEntry,
     SixteenColorsArtist, SixteenColorsGroup, ShadertoyUser, Tic80Dev, Pico8User,
     LinkedInUser, InstagramAccount, PolyworkUser, TikTokUser, MastodonAccount,
     WaybackMachinePage, BaseUrl,


### PR DESCRIPTION
Recognizes link to Plus4World that are of the /profile/<slug> form instead of /members. Unsure how profile and member differ