### PR TITLE
Add generic class-based view for editing forms

### DIFF
--- a/bbs/urls.py
+++ b/bbs/urls.py
@@ -9,7 +9,7 @@ urlpatterns = [
     path("<int:bbs_id>/", views.show, {}, "bbs"),
     path("new/", views.create, {}, "new_bbs"),
     path("<int:bbs_id>/edit/", views.edit, {}, "edit_bbs"),
-    path("<int:bbs_id>/edit_notes/", views.edit_notes, {}, "bbs_edit_notes"),
+    path("<int:bbs_id>/edit_notes/", views.EditNotesView.as_view(), {}, "bbs_edit_notes"),
     path("<int:bbs_id>/delete/", views.DeleteBBSView.as_view(), {}, "delete_bbs"),
     path("<int:bbs_id>/edit_bbstros/", views.edit_bbstros, {}, "bbs_edit_bbstros"),
     path("<int:bbs_id>/history/", views.history, {}, "bbs_history"),

--- a/bbs/views.py
+++ b/bbs/views.py
@@ -30,10 +30,10 @@ from common.utils.pagination import PaginationControls, extract_query_params
 from common.views import (
     AddTagView,
     AjaxConfirmationView,
-    EditingFormView,
     EditTagsView,
     EditTextFilesView,
     RemoveTagView,
+    UpdateFormView,
     writeable_site_required,
 )
 from demoscene.models import Edit
@@ -227,7 +227,7 @@ def edit(request, bbs_id):
     )
 
 
-class EditNotesView(EditingFormView):
+class EditNotesView(UpdateFormView):
     form_class = BBSEditNotesForm
     action_url_name = "bbs_edit_notes"
 

--- a/bbs/views.py
+++ b/bbs/views.py
@@ -30,13 +30,14 @@ from common.utils.pagination import PaginationControls, extract_query_params
 from common.views import (
     AddTagView,
     AjaxConfirmationView,
+    EditingFormView,
     EditTagsView,
     EditTextFilesView,
     RemoveTagView,
     writeable_site_required,
 )
 from demoscene.models import Edit
-from demoscene.shortcuts import get_page, simple_ajax_form
+from demoscene.shortcuts import get_page
 from search.indexing import index as search_index
 
 
@@ -226,19 +227,18 @@ def edit(request, bbs_id):
     )
 
 
-@writeable_site_required
-@login_required
-def edit_notes(request, bbs_id):
-    bbs = get_object_or_404(BBS, id=bbs_id)
-    if not request.user.is_staff:
-        return redirect("bbs", bbs.id)
+class EditNotesView(EditingFormView):
+    form_class = BBSEditNotesForm
+    action_url_name = "bbs_edit_notes"
 
-    def success(form):
-        form.log_edit(request.user)
+    def get_object(self):
+        return get_object_or_404(BBS, id=self.kwargs["bbs_id"])
 
-    return simple_ajax_form(
-        request, "bbs_edit_notes", bbs, BBSEditNotesForm, title="Editing notes for %s" % bbs.name, on_success=success
-    )
+    def can_edit(self, object):
+        return self.request.user.is_staff
+
+    def get_title(self):
+        return "Editing notes for %s" % self.object.name
 
 
 class DeleteBBSView(AjaxConfirmationView):

--- a/common/views.py
+++ b/common/views.py
@@ -1,6 +1,7 @@
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
+from django.contrib.auth.views import redirect_to_login
 from django.core.exceptions import ObjectDoesNotExist, PermissionDenied
 from django.db.models import Count
 from django.http import Http404, HttpResponseRedirect, JsonResponse
@@ -119,16 +120,22 @@ class EditingFormView(View):
     update_bonafide_flag = False
     update_datestamp = False
 
-    def get_object(self):
+    def get_object(self):  # pragma: no cover
         raise NotImplementedError
 
     def can_edit(self, object):
         return True
 
+    def get_login_return_url(self):
+        return self.request.get_full_path()
+
     @method_decorator(writeable_site_required)
-    @method_decorator(login_required)
     def dispatch(self, request, *args, **kwargs):
+        if not request.user.is_authenticated:
+            return redirect_to_login(self.get_login_return_url())
+
         self.object = self.get_object()
+
         if not self.can_edit(self.object):
             return HttpResponseRedirect(self.object.get_absolute_url())
 

--- a/common/views.py
+++ b/common/views.py
@@ -145,8 +145,11 @@ class EditingFormView(View):
 
         return super().dispatch(request, *args, **kwargs)
 
+    def get_form_kwargs(self):
+        return {"instance": self.object}
+
     def post(self, request, *args, **kwargs):
-        self.form = self.form_class(request.POST, instance=self.object)
+        self.form = self.form_class(request.POST, **self.get_form_kwargs())
         if self.form.is_valid():
             self.form_valid()
             return self.render_success_response()
@@ -163,7 +166,7 @@ class EditingFormView(View):
             return HttpResponseRedirect(self.object.get_absolute_url())
 
     def get(self, request, *args, **kwargs):
-        self.form = self.form_class(instance=self.object)
+        self.form = self.form_class(**self.get_form_kwargs())
         return self.render_to_response()
 
     def get_action_url(self):

--- a/common/views.py
+++ b/common/views.py
@@ -148,8 +148,14 @@ class EditingFormView(View):
     def get_form_kwargs(self):
         return {"instance": self.object}
 
+    def get_form(self):
+        if self.request.method == "POST":
+            return self.form_class(self.request.POST, self.request.FILES, **self.get_form_kwargs())
+        else:
+            return self.form_class(**self.get_form_kwargs())
+
     def post(self, request, *args, **kwargs):
-        self.form = self.form_class(request.POST, **self.get_form_kwargs())
+        self.form = self.get_form()
         if self.form.is_valid():
             self.form_valid()
             return self.render_success_response()
@@ -166,7 +172,7 @@ class EditingFormView(View):
             return HttpResponseRedirect(self.object.get_absolute_url())
 
     def get(self, request, *args, **kwargs):
-        self.form = self.form_class(**self.get_form_kwargs())
+        self.form = self.get_form()
         return self.render_to_response()
 
     def get_action_url(self):

--- a/common/views.py
+++ b/common/views.py
@@ -144,6 +144,7 @@ class EditingFormView(View):
             update_datestamp=self.update_datestamp,
             update_bonafide_flag=self.update_bonafide_flag,
             on_success=success,
+            ajax_submit=request.GET.get("ajax_submit"),
         )
 
 

--- a/demoscene/shortcuts.py
+++ b/demoscene/shortcuts.py
@@ -1,11 +1,4 @@
-import datetime
-
 from django.core.paginator import EmptyPage, InvalidPage, Paginator
-from django.http import HttpResponse, HttpResponseRedirect
-from django.shortcuts import render
-from django.urls import reverse
-
-from common.utils.ajax import request_is_ajax
 
 
 def get_page(queryset, page_number, **kwargs):
@@ -24,41 +17,3 @@ def get_page(queryset, page_number, **kwargs):
         return paginator.page(page)
     except (EmptyPage, InvalidPage):
         return paginator.page(paginator.num_pages)
-
-
-def simple_ajax_form(request, url_name, instance, form_class, **kwargs):
-    if request.method == "POST":
-        form = form_class(request.POST, instance=instance)
-        if form.is_valid():
-            if kwargs.get("update_datestamp", False):
-                instance.updated_at = datetime.datetime.now()
-            if kwargs.get("update_bonafide_flag", False):
-                instance.has_bonafide_edits = True
-            form.save()
-            if kwargs.get("on_success"):
-                kwargs["on_success"](form)
-            if kwargs.get("ajax_submit") and request_is_ajax(request):
-                return HttpResponse("OK", content_type="text/plain")
-            else:
-                return HttpResponseRedirect(instance.get_absolute_url())
-    else:
-        form = form_class(instance=instance)
-
-    title = kwargs.get("title")
-    if title and title.endswith(":"):
-        clean_title = title[:-1]
-    else:
-        clean_title = title
-
-    return render(
-        request,
-        "generic/simple_form.html",
-        {
-            "form": form,
-            "html_form_class": kwargs.get("html_form_class"),
-            "title": title,
-            "html_title": clean_title,
-            "action_url": reverse(url_name, args=[instance.id]),
-            "ajax_submit": kwargs.get("ajax_submit"),
-        },
-    )

--- a/demoscene/tests/test_scener_views.py
+++ b/demoscene/tests/test_scener_views.py
@@ -86,7 +86,7 @@ class TestEditLocation(TestCase):
     def test_locked(self):
         self.client.login(username="testuser", password="12345")
         response = self.client.get("/sceners/%d/edit_location/" % self.yerzmyey.id)
-        self.assertEqual(response.status_code, 403)
+        self.assertRedirects(response, "/sceners/%d/" % self.yerzmyey.id)
 
     def test_get(self):
         self.client.login(username="testuser", password="12345")

--- a/demoscene/urls.py
+++ b/demoscene/urls.py
@@ -10,7 +10,7 @@ urlpatterns = [
     path("groups/", groups_views.index, {}, "groups"),
     path("groups/<int:group_id>/", groups_views.show, {}, "group"),
     path("groups/<int:group_id>/history/", groups_views.history, {}, "group_history"),
-    path("groups/new/", groups_views.create, {}, "new_group"),
+    path("groups/new/", groups_views.CreateGroupView.as_view(), {}, "new_group"),
     path("groups/<int:group_id>/add_member/", groups_views.add_member, {}, "group_add_member"),
     path("groups/<int:group_id>/remove_member/<int:scener_id>/", groups_views.remove_member, {}, "group_remove_member"),
     path(

--- a/demoscene/urls.py
+++ b/demoscene/urls.py
@@ -58,7 +58,7 @@ urlpatterns = [
         {},
         "scener_convert_to_group",
     ),
-    path("releasers/<int:releaser_id>/edit_notes/", releasers_views.edit_notes, {}, "releaser_edit_notes"),
+    path("releasers/<int:releaser_id>/edit_notes/", releasers_views.EditNotesView.as_view(), {}, "releaser_edit_notes"),
     path("releasers/<int:releaser_id>/edit_nick/<int:nick_id>/", releasers_views.edit_nick, {}, "releaser_edit_nick"),
     path("releasers/<int:releaser_id>/add_nick/", releasers_views.add_nick, {}, "releaser_add_nick"),
     path(

--- a/demoscene/urls.py
+++ b/demoscene/urls.py
@@ -41,7 +41,7 @@ urlpatterns = [
     path("sceners/", sceners_views.index, {}, "sceners"),
     path("sceners/<int:scener_id>/", sceners_views.show, {}, "scener"),
     path("sceners/<int:scener_id>/history/", sceners_views.history, {}, "scener_history"),
-    path("sceners/new/", sceners_views.create, {}, "new_scener"),
+    path("sceners/new/", sceners_views.CreateScenerView.as_view(), {}, "new_scener"),
     path("sceners/<int:scener_id>/add_group/", sceners_views.add_group, {}, "scener_add_group"),
     path("sceners/<int:scener_id>/remove_group/<int:group_id>/", sceners_views.remove_group, {}, "scener_remove_group"),
     path(

--- a/demoscene/urls.py
+++ b/demoscene/urls.py
@@ -50,8 +50,12 @@ urlpatterns = [
         {},
         "scener_edit_membership",
     ),
-    path("sceners/<int:scener_id>/edit_location/", sceners_views.edit_location, {}, "scener_edit_location"),
-    path("sceners/<int:scener_id>/edit_real_name/", sceners_views.edit_real_name, {}, "scener_edit_real_name"),
+    path(
+        "sceners/<int:scener_id>/edit_location/", sceners_views.EditLocationView.as_view(), {}, "scener_edit_location"
+    ),
+    path(
+        "sceners/<int:scener_id>/edit_real_name/", sceners_views.EditRealNameView.as_view(), {}, "scener_edit_real_name"
+    ),
     path(
         "sceners/<int:scener_id>/convert_to_group/",
         sceners_views.ConvertToGroupView.as_view(),

--- a/demoscene/views/groups.py
+++ b/demoscene/views/groups.py
@@ -10,7 +10,7 @@ from django.shortcuts import get_object_or_404, render
 from django.urls import reverse
 
 from common.utils.pagination import PaginationControls
-from common.views import AjaxConfirmationView, writeable_site_required
+from common.views import AjaxConfirmationView, EditingFormView, writeable_site_required
 from demoscene.forms.releaser import CreateGroupForm, GroupMembershipForm, GroupSubgroupForm
 from demoscene.models import Edit, Membership, Nick, Releaser
 from demoscene.shortcuts import get_page
@@ -112,28 +112,14 @@ def history(request, group_id):
     )
 
 
-@writeable_site_required
-@login_required
-def create(request):
-    if request.method == "POST":
-        form = CreateGroupForm(request.POST)
-        if form.is_valid():
-            group = form.save()
-            form.log_creation(request.user)
-            return HttpResponseRedirect(group.get_absolute_url())
-    else:
-        form = CreateGroupForm()
+class CreateGroupView(EditingFormView):
+    form_class = CreateGroupForm
+    action_url_name = "new_group"
+    title = "New group"
 
-    return render(
-        request,
-        "generic/simple_form.html",
-        {
-            "form": form,
-            "title": "New group",
-            "html_title": "New group",
-            "action_url": reverse("new_group"),
-        },
-    )
+    def form_valid(self):
+        super().form_valid()
+        self.form.log_creation(self.request.user)
 
 
 @writeable_site_required

--- a/demoscene/views/releasers.py
+++ b/demoscene/views/releasers.py
@@ -8,7 +8,7 @@ from django.http import HttpResponseRedirect
 from django.shortcuts import get_object_or_404, render
 from django.urls import reverse
 
-from common.views import AjaxConfirmationView, EditingFormView, writeable_site_required
+from common.views import AjaxConfirmationView, UpdateFormView, writeable_site_required
 from demoscene.forms.releaser import (
     GroupNickForm,
     ReleaserEditNotesForm,
@@ -18,7 +18,7 @@ from demoscene.forms.releaser import (
 from demoscene.models import Edit, Nick, Releaser
 
 
-class EditNotesView(EditingFormView):
+class EditNotesView(UpdateFormView):
     form_class = ReleaserEditNotesForm
     action_url_name = "releaser_edit_notes"
     update_datestamp = True

--- a/demoscene/views/sceners.py
+++ b/demoscene/views/sceners.py
@@ -9,7 +9,7 @@ from django.shortcuts import get_object_or_404, render
 from django.urls import reverse
 
 from common.utils.pagination import PaginationControls
-from common.views import AjaxConfirmationView, EditingFormView, writeable_site_required
+from common.views import AjaxConfirmationView, EditingFormView, UpdateFormView, writeable_site_required
 from demoscene.forms.releaser import (
     CreateScenerForm,
     ScenerEditLocationForm,
@@ -100,7 +100,7 @@ def history(request, scener_id):
     )
 
 
-class EditLocationView(EditingFormView):
+class EditLocationView(UpdateFormView):
     form_class = ScenerEditLocationForm
     action_url_name = "scener_edit_location"
     update_datestamp = True
@@ -115,7 +115,7 @@ class EditLocationView(EditingFormView):
         return "Editing location for %s:" % self.object.name
 
 
-class EditRealNameView(EditingFormView):
+class EditRealNameView(UpdateFormView):
     form_class = ScenerEditRealNameForm
     action_url_name = "scener_edit_real_name"
     update_datestamp = True
@@ -130,28 +130,14 @@ class EditRealNameView(EditingFormView):
         return "Editing %s's real name:" % self.object.name
 
 
-@writeable_site_required
-@login_required
-def create(request):
-    if request.method == "POST":
-        form = CreateScenerForm(request.POST)
-        if form.is_valid():
-            scener = form.save()
-            form.log_creation(request.user)
-            return HttpResponseRedirect(scener.get_absolute_url())
-    else:
-        form = CreateScenerForm()
+class CreateScenerView(EditingFormView):
+    form_class = CreateScenerForm
+    action_url_name = "new_scener"
+    title = "New scener"
 
-    return render(
-        request,
-        "generic/simple_form.html",
-        {
-            "form": form,
-            "html_title": "New scener",
-            "title": "New scener",
-            "action_url": reverse("new_scener"),
-        },
-    )
+    def form_valid(self):
+        super().form_valid()
+        self.form.log_creation(self.request.user)
 
 
 @writeable_site_required

--- a/parties/tests/test_party_views.py
+++ b/parties/tests/test_party_views.py
@@ -424,6 +424,11 @@ class TestEditSeriesNotes(TestCase):
         self.client.login(username="testsuperuser", password="12345")
         self.party_series = PartySeries.objects.get(name="Forever")
 
+    def test_not_logged_in(self):
+        self.client.logout()
+        response = self.client.get("/parties/series/%d/edit_notes/" % self.party_series.id)
+        self.assertRedirects(response, "/account/login/?next=/parties/series/%d/edit_notes/" % self.party_series.id)
+
     def test_non_superuser(self):
         User.objects.create_user(username="testuser", password="12345")
         self.client.login(username="testuser", password="12345")

--- a/parties/tests/test_party_views.py
+++ b/parties/tests/test_party_views.py
@@ -479,6 +479,18 @@ class TestEditSeries(TestCase):
         ps = PartySeries.objects.get(id=self.party_series.id)
         self.assertEqual(ps.website, "http://forever.zeroteam.sk/")
 
+    def test_post_invalid(self):
+        response = self.client.post(
+            "/parties/series/%d/edit/" % self.party_series.id,
+            {
+                "name": "",
+                "website": "http://forever.zeroteam.sk/",
+            },
+        )
+        self.assertEqual(response.status_code, 200)
+        ps = PartySeries.objects.get(id=self.party_series.id)
+        self.assertEqual(ps.name, "Forever")
+
 
 class TestAddCompetition(TestCase):
     fixtures = ["tests/gasman.json"]

--- a/parties/urls.py
+++ b/parties/urls.py
@@ -16,7 +16,7 @@ urlpatterns = [
     path("parties/<int:party_id>/history/", party_views.history, {}, "party_history"),
     path("parties/series/<int:party_series_id>/", party_views.show_series, {}, "party_series"),
     path("parties/series/<int:party_series_id>/history/", party_views.series_history, {}, "party_series_history"),
-    path("parties/series/<int:party_series_id>/edit/", party_views.edit_series, {}, "party_edit_series"),
+    path("parties/series/<int:party_series_id>/edit/", party_views.EditSeriesView.as_view(), {}, "party_edit_series"),
     path(
         "parties/series/<int:party_series_id>/edit_notes/",
         party_views.EditSeriesNotesView.as_view(),

--- a/parties/urls.py
+++ b/parties/urls.py
@@ -18,7 +18,10 @@ urlpatterns = [
     path("parties/series/<int:party_series_id>/history/", party_views.series_history, {}, "party_series_history"),
     path("parties/series/<int:party_series_id>/edit/", party_views.edit_series, {}, "party_edit_series"),
     path(
-        "parties/series/<int:party_series_id>/edit_notes/", party_views.edit_series_notes, {}, "party_edit_series_notes"
+        "parties/series/<int:party_series_id>/edit_notes/",
+        party_views.EditSeriesNotesView.as_view(),
+        {},
+        "party_edit_series_notes",
     ),
     path(
         "parties/series/<int:party_series_id>/edit_external_links/",
@@ -35,7 +38,7 @@ urlpatterns = [
         {},
         "party_edit_competition",
     ),
-    path("parties/<int:party_id>/edit_notes/", party_views.edit_notes, {}, "party_edit_notes"),
+    path("parties/<int:party_id>/edit_notes/", party_views.EditNotesView.as_view(), {}, "party_edit_notes"),
     path(
         "parties/<int:party_id>/edit_external_links/", party_views.edit_external_links, {}, "party_edit_external_links"
     ),

--- a/parties/views/parties.py
+++ b/parties/views/parties.py
@@ -17,7 +17,7 @@ from django.utils.http import urlencode
 from comments.forms import CommentForm
 from comments.models import Comment
 from common.utils.ajax import request_is_ajax
-from common.views import AjaxConfirmationView, EditingFormView, writeable_site_required
+from common.views import AjaxConfirmationView, UpdateFormView, writeable_site_required
 from demoscene.models import Edit
 from parties.forms import (
     CompetitionForm,
@@ -252,7 +252,7 @@ def edit(request, party_id):
     )
 
 
-class EditNotesView(EditingFormView):
+class EditNotesView(UpdateFormView):
     form_class = PartyEditNotesForm
     action_url_name = "party_edit_notes"
 
@@ -333,7 +333,7 @@ def edit_series_external_links(request, party_series_id):
     )
 
 
-class EditSeriesNotesView(EditingFormView):
+class EditSeriesNotesView(UpdateFormView):
     form_class = PartySeriesEditNotesForm
     action_url_name = "party_edit_series_notes"
 
@@ -347,7 +347,7 @@ class EditSeriesNotesView(EditingFormView):
         return "Editing notes for %s" % self.object.name
 
 
-class EditSeriesView(EditingFormView):
+class EditSeriesView(UpdateFormView):
     form_class = EditPartySeriesForm
     action_url_name = "party_edit_series"
 

--- a/parties/views/parties.py
+++ b/parties/views/parties.py
@@ -19,7 +19,6 @@ from comments.models import Comment
 from common.utils.ajax import request_is_ajax
 from common.views import AjaxConfirmationView, EditingFormView, writeable_site_required
 from demoscene.models import Edit
-from demoscene.shortcuts import simple_ajax_form
 from parties.forms import (
     CompetitionForm,
     EditPartyForm,
@@ -348,28 +347,21 @@ class EditSeriesNotesView(EditingFormView):
         return "Editing notes for %s" % self.object.name
 
 
-@writeable_site_required
-def edit_series(request, party_series_id):
-    if not request.user.is_authenticated:
+class EditSeriesView(EditingFormView):
+    form_class = EditPartySeriesForm
+    action_url_name = "party_edit_series"
+
+    def get_object(self):
+        return get_object_or_404(PartySeries, id=self.kwargs["party_series_id"])
+
+    def get_title(self):
+        return "Editing party: %s" % self.object.name
+
+    def get_login_return_url(self):
         # Instead of redirecting back to this edit form after login, redirect to the party series page.
         # This is because the edit button pointing here is the only one a non-logged-in user sees,
         # so they may intend to edit something else on the party series page.
-        return redirect_to_login(reverse("party_series", args=[party_series_id]))
-
-    party_series = get_object_or_404(PartySeries, id=party_series_id)
-
-    def success(form):
-        form.log_edit(request.user)
-
-    return simple_ajax_form(
-        request,
-        "party_edit_series",
-        party_series,
-        EditPartySeriesForm,
-        title="Editing party: %s" % party_series.name,
-        on_success=success,
-        # update_datestamp = True
-    )
+        return reverse("party_series", args=[self.kwargs["party_series_id"]])
 
 
 @writeable_site_required

--- a/parties/views/parties.py
+++ b/parties/views/parties.py
@@ -17,7 +17,7 @@ from django.utils.http import urlencode
 from comments.forms import CommentForm
 from comments.models import Comment
 from common.utils.ajax import request_is_ajax
-from common.views import AjaxConfirmationView, writeable_site_required
+from common.views import AjaxConfirmationView, EditingFormView, writeable_site_required
 from demoscene.models import Edit
 from demoscene.shortcuts import simple_ajax_form
 from parties.forms import (
@@ -253,25 +253,18 @@ def edit(request, party_id):
     )
 
 
-@writeable_site_required
-@login_required
-def edit_notes(request, party_id):
-    party = get_object_or_404(Party, id=party_id)
-    if not request.user.is_staff:
-        return HttpResponseRedirect(party.get_absolute_url())
+class EditNotesView(EditingFormView):
+    form_class = PartyEditNotesForm
+    action_url_name = "party_edit_notes"
 
-    def success(form):
-        form.log_edit(request.user)
+    def get_object(self):
+        return get_object_or_404(Party, id=self.kwargs["party_id"])
 
-    return simple_ajax_form(
-        request,
-        "party_edit_notes",
-        party,
-        PartyEditNotesForm,
-        title="Editing notes for %s" % party.name,
-        on_success=success,
-        # update_datestamp = True
-    )
+    def can_edit(self, object):
+        return self.request.user.is_staff
+
+    def get_title(self):
+        return "Editing notes for %s" % self.object.name
 
 
 @writeable_site_required
@@ -341,25 +334,18 @@ def edit_series_external_links(request, party_series_id):
     )
 
 
-@writeable_site_required
-@login_required
-def edit_series_notes(request, party_series_id):
-    party_series = get_object_or_404(PartySeries, id=party_series_id)
-    if not request.user.is_staff:
-        return HttpResponseRedirect(party_series.get_absolute_url())
+class EditSeriesNotesView(EditingFormView):
+    form_class = PartySeriesEditNotesForm
+    action_url_name = "party_edit_series_notes"
 
-    def success(form):
-        form.log_edit(request.user)
+    def get_object(self):
+        return get_object_or_404(PartySeries, id=self.kwargs["party_series_id"])
 
-    return simple_ajax_form(
-        request,
-        "party_edit_series_notes",
-        party_series,
-        PartySeriesEditNotesForm,
-        title="Editing notes for %s" % party_series.name,
-        on_success=success,
-        # update_datestamp = True
-    )
+    def can_edit(self, object):
+        return self.request.user.is_staff
+
+    def get_title(self):
+        return "Editing notes for %s" % self.object.name
 
 
 @writeable_site_required

--- a/productions/urls.py
+++ b/productions/urls.py
@@ -58,7 +58,12 @@ urlpatterns = [
         {},
         "production_delete_credit",
     ),
-    path("productions/<int:production_id>/edit_notes/", production_views.edit_notes, {}, "production_edit_notes"),
+    path(
+        "productions/<int:production_id>/edit_notes/",
+        production_views.EditNotesView.as_view(),
+        {},
+        "production_edit_notes",
+    ),
     path(
         "productions/<int:production_id>/edit_external_links/",
         production_views.edit_external_links,

--- a/productions/urls.py
+++ b/productions/urls.py
@@ -145,7 +145,12 @@ urlpatterns = [
         {},
         "delete_production",
     ),
-    path("productions/<int:production_id>/add_blurb/", production_views.add_blurb, {}, "production_add_blurb"),
+    path(
+        "productions/<int:production_id>/add_blurb/",
+        production_views.AddBlurbView.as_view(),
+        {},
+        "production_add_blurb",
+    ),
     path(
         "productions/<int:production_id>/edit_blurb/<int:blurb_id>/",
         production_views.edit_blurb,

--- a/productions/views/productions.py
+++ b/productions/views/productions.py
@@ -21,10 +21,10 @@ from common.utils.pagination import PaginationControls, extract_query_params
 from common.views import (
     AddTagView,
     AjaxConfirmationView,
-    EditingFormView,
     EditTagsView,
     EditTextFilesView,
     RemoveTagView,
+    UpdateFormView,
     writeable_site_required,
 )
 from demoscene.forms.common import CreditFormSet
@@ -218,7 +218,7 @@ def edit_core_details(request, production_id):
     )
 
 
-class EditNotesView(EditingFormView):
+class EditNotesView(UpdateFormView):
     form_class = ProductionEditNotesForm
     action_url_name = "production_edit_notes"
     update_bonafide_flag = True

--- a/users/urls.py
+++ b/users/urls.py
@@ -11,7 +11,7 @@ urlpatterns = [
     path("account/login/", account_views.LoginViewWithIPCheck.as_view(), {}, "log_in"),
     path("account/logout/", auth_views.LogoutView.as_view(next_page="/"), {}, "log_out"),
     path("account/signup/", account_views.signup, {}, "user_signup"),
-    path("account/change_password/", account_views.change_password, {}, "account_change_password"),
+    path("account/change_password/", account_views.ChangePasswordView.as_view(), {}, "account_change_password"),
     # forgotten password
     path("account/forgotten_password/", auth_views.PasswordResetView.as_view(), {}, "password_reset"),
     path("account/forgotten_password/success/", auth_views.PasswordResetDoneView.as_view(), {}, "password_reset_done"),

--- a/users/views/accounts.py
+++ b/users/views/accounts.py
@@ -4,10 +4,9 @@ from django.contrib.auth.decorators import login_required
 from django.contrib.auth.forms import PasswordChangeForm
 from django.contrib.auth.views import LoginView
 from django.shortcuts import redirect, render
-from django.urls import reverse
 
 from common.utils.ajax import request_is_ajax
-from common.views import writeable_site_required
+from common.views import EditingFormView, writeable_site_required
 from demoscene.forms.account import UserSignupForm
 from demoscene.models import CaptchaQuestion
 from users.utils import is_login_banned, is_registration_banned
@@ -71,25 +70,16 @@ def signup(request):
     )
 
 
-@writeable_site_required
-@login_required
-def change_password(request):
-    if request.method == "POST":
-        form = PasswordChangeForm(request.user, request.POST)
-        if form.is_valid():
-            form.save()
-            messages.success(request, "Password updated")
-            return redirect("home")
-    else:
-        form = PasswordChangeForm(request.user)
+class ChangePasswordView(EditingFormView):
+    page_title = "Change password"
+    action_url_name = "account_change_password"
 
-    return render(
-        request,
-        "generic/simple_form.html",
-        {
-            "form": form,
-            "title": "Change password",
-            "html_title": "Change password",
-            "action_url": reverse("account_change_password"),
-        },
-    )
+    def get_form(self):
+        if self.request.method == "POST":
+            return PasswordChangeForm(self.request.user, self.request.POST)
+        else:
+            return PasswordChangeForm(self.request.user)
+
+    def render_success_response(self):
+        messages.success(self.request, "Password updated")
+        return redirect("home")


### PR DESCRIPTION
Replace the `simple_ajax_form` helper with some generic class-based views to reduce code duplication