### PR TITLE
List scener with ex-groups in case of no current groups found

### DIFF
--- a/demoscene/fixtures/tests/gasman.json
+++ b/demoscene/fixtures/tests/gasman.json
@@ -210,6 +210,28 @@
     },
 
     {
+        "pk": 10,
+        "model": "demoscene.releaser",
+        "fields": {
+            "name": "Grouphopper",
+            "is_group": false,
+            "created_at": "2014-01-01",
+            "updated_at": "2014-01-01"
+        }
+    },
+    {
+        "pk": 11,
+        "model": "demoscene.nick",
+        "fields": {"releaser": 10, "name": "Grouphopper"}
+    },
+    {
+        "pk": 12,
+        "model": "demoscene.nickvariant",
+        "fields": {"nick": 11, "name": "Grouphopper", "search_title": "grouphopper"}
+    },
+
+
+    {
         "pk": 1,
         "model": "demoscene.membership",
         "fields": {"member": 1, "group": 2}
@@ -249,6 +271,16 @@
         "model": "demoscene.membership",
         "fields": {"member": 8, "group": 9}
     },
+    {
+        "pk": 9,
+        "model": "demoscene.membership",
+        "fields": {"member": 10, "group": 9, "is_current": false}
+    },
+    {
+        "pk": 10,
+        "model": "demoscene.membership",
+        "fields": {"member": 10, "group": 4, "is_current": false}
+    },    
 
     {
         "pk": 1,

--- a/demoscene/models.py
+++ b/demoscene/models.py
@@ -193,7 +193,7 @@ class Releaser(URLMixin, LocationMixin, PrefetchSnoopingMixin, Lockable):
                 else:
                     # use full group names - not too long
                     group_names = [group.name for group in groups]
-                return "%s / %s" % (self.name, " ^ ".join("ex-"+group for group in group_names)) 
+                return "%s / %s" % (self.name, " ^ ".join("ex-"+group for group in group_names))
             else:
                 return self.name
 
@@ -402,7 +402,7 @@ class Nick(PrefetchSnoopingMixin, models.Model):
                 else:
                     # use full group names - not too long
                     group_names = [group.name for group in groups]
-                return "%s / %s" % (self.name, " ^ ".join("ex-"+group for group in group_names)) 
+                return "%s / %s" % (self.name, " ^ ".join("ex-"+group for group in group_names))
             else:
                 return self.name
 

--- a/demoscene/models.py
+++ b/demoscene/models.py
@@ -183,7 +183,19 @@ class Releaser(URLMixin, LocationMixin, PrefetchSnoopingMixin, Lockable):
                 group_names = [group.name for group in groups]
             return "%s / %s" % (self.name, " ^ ".join(group_names))
         else:
-            return self.name
+            # no current groups, list ex groups instead
+            groups = self.groups()
+
+            if groups:
+                if sum([len(group.name) for group in groups]) >= 20:
+                    # abbreviate where possible
+                    group_names = [(group.abbreviation or group.name) for group in groups]
+                else:
+                    # use full group names - not too long
+                    group_names = [group.name for group in groups]
+                return "%s / %s" % (self.name, " ^ ".join("ex-"+group for group in group_names)) 
+            else:
+                return self.name
 
     @property
     def primary_nick(self):
@@ -380,7 +392,19 @@ class Nick(PrefetchSnoopingMixin, models.Model):
                 group_names = [group.name for group in groups]
             return "%s / %s" % (self.name, " ^ ".join(group_names))
         else:
-            return self.name
+            # no current groups, list ex groups instead
+            groups = self.releaser.groups()
+
+            if groups:
+                if sum([len(group.name) for group in groups]) >= 20:
+                    # abbreviate where possible
+                    group_names = [(group.abbreviation or group.name) for group in groups]
+                else:
+                    # use full group names - not too long
+                    group_names = [group.name for group in groups]
+                return "%s / %s" % (self.name, " ^ ".join("ex-"+group for group in group_names)) 
+            else:
+                return self.name
 
     # Determine whether or not this nick is referenced in any external records (credits, authorships etc)
     def is_referenced(self):

--- a/demoscene/tests/test_models.py
+++ b/demoscene/tests/test_models.py
@@ -171,6 +171,10 @@ class TestReleaserString(TestCase):
         # do not abbreviate groups that don't have abbreviations (duh)
         self.assertEqual(laesq.name_with_affiliations(), "LaesQ / Papaya Dezign ^ RA")
 
+        grouphopper = Releaser.objects.get(name="Grouphopper")
+        # add ex- to group names if no current groups
+        self.assertEqual(grouphopper.name_with_affiliations(), "Grouphopper / ex-Future Crew ^ ex-H-Prg")
+
 
 class TestReleaserNicks(TestCase):
     fixtures = ["tests/gasman.json"]


### PR DESCRIPTION
To improve production credits editing as well as generally identifying sceners, ex groups are listed (prefixed with "ex-" for each of the groups, for example _Grouphopper / ex-Future Crew ^ ex-H-Prg_) if a sceners has no current group.