### PR TITLE
Optimise duplicate external links report

### DIFF
--- a/maintenance/templates/maintenance/duplicate_production_external_links.html
+++ b/maintenance/templates/maintenance/duplicate_production_external_links.html
@@ -7,10 +7,11 @@
 
 {% block base_main %}
     <div id="main_column">
-        {% for column, productions in prod_dupes.items %}
-            <h2>Productions matching by {{ column }}:</h2>
+        {% regroup duplicate_prods by duplicate_link_class as link_class_list %}
+        {% for link_class in link_class_list %}
+            <h2>Productions matching by {{ link_class.grouper }}:</h2>
             <div class="panel report">
-                {% production_listing productions %}
+                {% production_listing link_class.list %}
             </div>
         {% endfor %}
     </div>

--- a/maintenance/templates/maintenance/duplicate_production_external_links.html
+++ b/maintenance/templates/maintenance/duplicate_production_external_links.html
@@ -1,0 +1,17 @@
+{% extends "maintenance/base.html" %}
+{% load production_tags %}
+
+{% block html_title %}Duplicate production external links - Demozoo{% endblock %}
+
+{% block body_class %}maintenance_report{% endblock %}
+
+{% block base_main %}
+    <div id="main_column">
+        {% for column, productions in prod_dupes.items %}
+            <h2>Productions matching by {{ column }}:</h2>
+            <div class="panel report">
+                {% production_listing productions %}
+            </div>
+        {% endfor %}
+    </div>
+{% endblock %}

--- a/maintenance/templates/maintenance/duplicate_releaser_external_links.html
+++ b/maintenance/templates/maintenance/duplicate_releaser_external_links.html
@@ -7,11 +7,12 @@
 
 {% block base_main %}
     <div id="main_column">
-        {% for column, releasers in releaser_dupes.items %}
-            <h2>Releasers matching by {{ column }}:</h2>
+        {% regroup duplicate_releasers by duplicate_link_class as link_class_list %}
+        {% for link_class in link_class_list %}
+            <h2>Releasers matching by {{ link_class.grouper }}:</h2>
             <div class="panel report">
                 <ul class="releaser_list">
-                    {% for releaser in releasers %}
+                    {% for releaser in link_class.list %}
                         <li class="{% if releaser.is_group %}group{% else %}scener{% endif %}">
                             <a href="{{ releaser.get_absolute_url }}">{{ releaser.name }}</a>
                         </li>

--- a/maintenance/templates/maintenance/duplicate_releaser_external_links.html
+++ b/maintenance/templates/maintenance/duplicate_releaser_external_links.html
@@ -1,0 +1,23 @@
+{% extends "maintenance/base.html" %}
+{% load production_tags %}
+
+{% block html_title %}Duplicate releaser external links - Demozoo{% endblock %}
+
+{% block body_class %}maintenance_report{% endblock %}
+
+{% block base_main %}
+    <div id="main_column">
+        {% for column, releasers in releaser_dupes.items %}
+            <h2>Releasers matching by {{ column }}:</h2>
+            <div class="panel report">
+                <ul class="releaser_list">
+                    {% for releaser in releasers %}
+                        <li class="{% if releaser.is_group %}group{% else %}scener{% endif %}">
+                            <a href="{{ releaser.get_absolute_url }}">{{ releaser.name }}</a>
+                        </li>
+                    {% endfor %}
+                </ul>
+            </div>
+        {% endfor %}
+    </div>
+{% endblock %}

--- a/maintenance/tests/test_views.py
+++ b/maintenance/tests/test_views.py
@@ -132,13 +132,16 @@ class TestReports(TestCase):
         response = self.client.get("/maintenance/same_named_prods_without_special_chars/")
         self.assertEqual(response.status_code, 200)
 
-    def test_duplicate_external_links(self):
+    def test_duplicate_production_external_links(self):
         Production.objects.get(title="Pondlife").links.create(link_class="PouetProduction", parameter="123")
         Production.objects.get(title="Madrielle").links.create(link_class="PouetProduction", parameter="123")
+        response = self.client.get("/maintenance/duplicate_production_external_links/")
+        self.assertEqual(response.status_code, 200)
 
+    def test_duplicate_releaser_external_links(self):
         Releaser.objects.get(name="Gasman").external_links.create(link_class="PouetGroup", parameter="123")
         Releaser.objects.get(name="Raww Arse").external_links.create(link_class="PouetGroup", parameter="123")
-        response = self.client.get("/maintenance/duplicate_external_links/")
+        response = self.client.get("/maintenance/duplicate_releaser_external_links/")
         self.assertEqual(response.status_code, 200)
 
     def test_duplicate_releaser_kestra_links(self):

--- a/maintenance/views.py
+++ b/maintenance/views.py
@@ -640,10 +640,10 @@ class SameNamedProdsWithoutSpecialChars(StaffOnlyMixin, Report):
         return context
 
 
-class DuplicateExternalLinks(StaffOnlyMixin, Report):
-    title = "Duplicate external links"
-    template_name = "maintenance/duplicate_external_links.html"
-    name = "duplicate_external_links"
+class DuplicateProductionExternalLinks(StaffOnlyMixin, Report):
+    title = "Duplicate production external links"
+    template_name = "maintenance/duplicate_production_external_links.html"
+    name = "duplicate_production_external_links"
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
@@ -668,6 +668,26 @@ class DuplicateExternalLinks(StaffOnlyMixin, Report):
                 [link_class],
             )
 
+        prod_dupes = {}
+        for link_class in ProductionLink.objects.distinct().values_list("link_class", flat=True):
+            prod_dupes[link_class] = prod_duplicates_by_link_class(link_class)
+
+        context.update(
+            {
+                "prod_dupes": prod_dupes,
+            }
+        )
+        return context
+
+
+class DuplicateReleaserExternalLinks(StaffOnlyMixin, Report):
+    title = "Duplicate releaser external links"
+    template_name = "maintenance/duplicate_releaser_external_links.html"
+    name = "duplicate_releaser_external_links"
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+
         def releaser_duplicates_by_link_class(link_class):
             return Releaser.objects.raw(
                 """
@@ -686,17 +706,12 @@ class DuplicateExternalLinks(StaffOnlyMixin, Report):
                 [link_class],
             )
 
-        prod_dupes = {}
-        for link_class in ProductionLink.objects.distinct().values_list("link_class", flat=True):
-            prod_dupes[link_class] = prod_duplicates_by_link_class(link_class)
-
         releaser_dupes = {}
         for link_class in ReleaserExternalLink.objects.distinct().values_list("link_class", flat=True):
             releaser_dupes[link_class] = releaser_duplicates_by_link_class(link_class)
 
         context.update(
             {
-                "prod_dupes": prod_dupes,
                 "releaser_dupes": releaser_dupes,
             }
         )
@@ -1861,7 +1876,8 @@ reports = [
             ProdsWithSameNamedCredits,
             SameNamedProdsBySameReleaser,
             SameNamedProdsWithoutSpecialChars,
-            DuplicateExternalLinks,
+            DuplicateProductionExternalLinks,
+            DuplicateReleaserExternalLinks,
             DuplicateReleaserKestraLinks,
             MatchingRealNames,
             MatchingSurnames,


### PR DESCRIPTION
Ref: #410

Split the duplicate external links report into separate reports for productions and releasers, and rewrite the main query to perform a `GROUP BY` on the link class/parameter rather than joining the table against itself. In efficiency terms it's now essentially finding duplicates in an ordered list rather than an unordered one...

The production report now completes in around 5 seconds on my local machine, which may be borderline for working without crashing on the live site, but that's down from over 100 seconds, so worth trying out at least :-)