### PR TITLE
Set up nepenthes honeypot for AI crawlers

### DIFF
--- a/common/templates/base.html
+++ b/common/templates/base.html
@@ -145,7 +145,7 @@
                         --><li>Kindly hosted by <a href="https://zetta.io/">zetta.io</a></li><!--
                         --><li><a href="{% url 'page' 'faq' %}">FAQ</a></li><!--
                         --><li><a href="https://discord.gg/AJ2xV8X">Discord</a></li><!--
-                        --><li><a href="https://github.com/demozoo/demozoo">Get the source</a></li>
+                        --><li><a href="https://github.com/demozoo/demozoo">Get the source</a></li>{% block footer_extra_links %}{% endblock %}
                     </ul>
                 </nav>
             </div>

--- a/demoscene/management/commands/dump_ai_corpus.py
+++ b/demoscene/management/commands/dump_ai_corpus.py
@@ -1,0 +1,16 @@
+# output a whole load of text sourced from our notes
+
+import re
+
+from django.core.management.base import BaseCommand
+
+from demoscene.models import Releaser
+from productions.models import Production
+
+
+class Command(BaseCommand):
+    def handle(self, *args, **kwargs):
+        for model in [Production, Releaser]:
+            for note in model.objects.exclude(notes="").values_list("notes", flat=True):
+                note = re.sub(r"https?://\S+", "", note)
+                print(note)

--- a/etc/demozoo-productionvm-nginx.conf
+++ b/etc/demozoo-productionvm-nginx.conf
@@ -104,6 +104,13 @@ server {
         limit_req zone=dzapi burst=10 delay=5;
     }
 
+    location /beep-boop/ {
+        proxy_pass http://localhost:8893;
+        proxy_set_header X-Prefix '/beep-boop';
+        proxy_set_header X-Forwarded-For $remote_addr;
+        proxy_buffering off;
+    }
+
     location /static {
         root   /home/demozoo/demozoo;
     }

--- a/etc/demozoo-staging-nginx.conf
+++ b/etc/demozoo-staging-nginx.conf
@@ -97,6 +97,13 @@ server {
         auth_basic_user_file /home/demozoo/demozoo/etc/staging.htpasswd;
     }
 
+    location /beep-boop/ {
+        proxy_pass http://localhost:8893;
+        proxy_set_header X-Prefix '/beep-boop';
+        proxy_set_header X-Forwarded-For $remote_addr;
+        proxy_buffering off;
+    }
+
     location /static {
         root   /home/demozoo/demozoo;
     }

--- a/etc/nepenthes-supervisor.conf
+++ b/etc/nepenthes-supervisor.conf
@@ -1,0 +1,8 @@
+[program:nepenthes]
+command=/home/nepenthes/nepenthes /home/nepenthes/config.yml
+directory=/home/nepenthes
+autostart=true
+autorestart=true
+redirect_stderr=True
+user=nepenthes
+stopsignal=QUIT

--- a/users/templates/registration/login.html
+++ b/users/templates/registration/login.html
@@ -40,3 +40,5 @@
         </div>
     </form>
 {% endblock %}
+
+{% block footer_extra_links %}<li><a href="/beep-boop/">I am a robot, beep boop</a></li>{% endblock %}


### PR DESCRIPTION
Demozoo has been getting a lot of bot traffic, including some particularly bad offenders that make tens/hundreds of requests per second, ignore robots.txt, use fake untrackable user agents and use a wide IP block to evade rate limiting. Add a [nepenthes](https://zadzmo.org/code/nepenthes/) honeypot (disallowed by robots.txt to keep out legitimate bots such as Google) to hopefully tie up their resources and keep them off the real site.