### PR TITLE
Introduce new templatetag (filter) to urlize (s)ftp://-links

### DIFF
--- a/comments/templates/comments/_comments.html
+++ b/comments/templates/comments/_comments.html
@@ -1,4 +1,4 @@
-
+{% load ui_tags }
 
 {% with commentable.get_comments as comments %}
     {% if comments or site_is_writeable %}
@@ -16,7 +16,7 @@
                             {% endif %}
                             <b>{{ comment.user.username }}</b> - {{ comment.created_at|date:"H:i j F Y" }}
                             <a href="{{ comment.get_absolute_url }}">#</a>
-                            <p>{{ comment.body|urlize|linebreaks }}</p>
+                            <p>{{ comment.body|urlize|urlize_ftp|linebreaks }}</p>
                         </div>
                     {% endfor %}
                 </div>

--- a/comments/templates/comments/_comments.html
+++ b/comments/templates/comments/_comments.html
@@ -1,4 +1,4 @@
-{% load ui_tags }
+{% load ui_tags %}
 
 {% with commentable.get_comments as comments %}
     {% if comments or site_is_writeable %}

--- a/common/templatetags/ui_tags.py
+++ b/common/templatetags/ui_tags.py
@@ -1,3 +1,5 @@
+import re
+
 from django import template
 from django.urls import reverse
 
@@ -81,3 +83,13 @@ def icon_button(url=None, **kwargs):
 @register.inclusion_tag("tags/icon_button.html")
 def edit_button(icon="edit", **kwargs):
     return icon_button(icon=icon, **kwargs)
+
+
+# replace (s)ftp:// urls with clickable link
+@register.filter(is_safe=True)
+def urlize_ftp(text):
+    if "ftp://" in text:
+        return re.sub(r'((s?ftp):\/\/(?:([^@\s]+)@)?([^\?\s\:]+)(?:\:([0-9]+))?(?:\?(.+))?)',
+                      r'<a href="\1">\1</a>',
+                      text)
+    return text

--- a/forums/templates/forums/topic.html
+++ b/forums/templates/forums/topic.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load demoscene_tags compress laces %}
+{% load demoscene_tags ui_tags compress laces %}
 
 
 {% block html_title %}{{ topic.title }} - Discussions - Demozoo{% endblock %}
@@ -27,7 +27,7 @@
                     {% endif %}
                     <b>{{ post.user.username }}</b> - {{ post.created_at|date:"H:i j F Y" }}
                     <a href="{{ post.get_absolute_url }}" title="Permalink">#</a>
-                    <p>{{ post.body|urlize|linebreaks }}</p>
+                    <p>{{ post.body|urlize|urlize_ftp|linebreaks }}</p>
                 </div>
             {% endfor %}
         </div>


### PR DESCRIPTION
As requested in https://github.com/demozoo/demozoo/issues/130
Does _not_ recognize FTP URLs without protocol (ftp:// or sftp://)
Added recognition of FTP URLs in comments & forums. Could possibly also be used in free text fields all over the place.