### PR TITLE
Stop first character of input in compo results table from being swallowed up on Firefox

### DIFF
--- a/demoscene/static/js/editable_grid.js
+++ b/demoscene/static/js/editable_grid.js
@@ -640,20 +640,19 @@ function TextGridCell(opts) {
     self.keydown = function(event) {
         switch (self._editMode) {
             case null:
-                switch (event.key) {
-                    case "Enter":
-                        self._startEdit('capturedText');
-                        return false;
-                    case "Backspace":
-                        self._startEdit('uncapturedText');
-                        input.val('');
-                        return false;
-                    case "v":
-                        if (self.eventIsCommandKey(event)) { /* cmd+V = paste */
-                            self._startEdit('uncapturedText');
-                            return true; /* override grid event handler, defer to browser's own */
-                        }
-                        break;
+                if (event.key === "Enter") {
+                    self._startEdit('capturedText');
+                    return false;
+                } else if (event.key === "Backspace") {
+                    self._startEdit('uncapturedText');
+                    input.val('');
+                    return false;
+                } else if (event.key === "v" && self.eventIsCommandKey(event)) {
+                    /* cmd+V = paste */
+                    self._startEdit('uncapturedText');
+                    return true; /* override grid event handler, defer to browser's own */
+                } else if (event.key.length === 1) {
+                    self._startEdit('uncapturedText');
                 }
                 break;
             case 'capturedText':
@@ -686,13 +685,6 @@ function TextGridCell(opts) {
                         self._finishEdit();
                         return null; /* let grid event handler process the cursor movement */
                 }
-                break;
-        }
-    }
-    self.keypress = function(event) {
-        switch (self._editMode) {
-            case null:
-                self._startEdit('uncapturedText');
                 break;
         }
     }

--- a/demoscene/static/js/editable_grid.js
+++ b/demoscene/static/js/editable_grid.js
@@ -141,9 +141,8 @@ function EditableGrid(elem) {
                 - true to pass control to the browser's default handlers */
             if (result != null) return result;
         }
-        
-        switch (event.which) {
-            case 9: /* tab */
+        switch (event.key) {
+            case "Tab":
                 if (event.shiftKey) {
                     if (moveCursorBackward()) {
                         return false;
@@ -161,22 +160,22 @@ function EditableGrid(elem) {
                         return;
                     }
                 }
-            case 13: /* enter */
+            case "Enter":
                 advanceOrCreate();
                 return false;
-            case 37: /* cursor left */
+            case "ArrowLeft":
                 setCursorIfInRange(cursorX - 1, cursorY);
                 //resultsTable.focus();
                 return false;
-            case 38: /* cursor up */
+            case "ArrowUp":
                 setCursorIfInRange(cursorX, cursorY - 1);
                 //resultsTable.focus();
                 return false;
-            case 39: /* cursor right */
+            case "ArrowRight":
                 setCursorIfInRange(cursorX + 1, cursorY);
                 //resultsTable.focus();
                 return false;
-            case 40: /* cursor down */
+            case "ArrowDown":
                 setCursorIfInRange(cursorX, cursorY + 1);
                 //resultsTable.focus();
                 return false;
@@ -641,15 +640,15 @@ function TextGridCell(opts) {
     self.keydown = function(event) {
         switch (self._editMode) {
             case null:
-                switch (event.which) {
-                    case 13:
+                switch (event.key) {
+                    case "Enter":
                         self._startEdit('capturedText');
                         return false;
-                    case 8: /* backspace */
+                    case "Backspace":
                         self._startEdit('uncapturedText');
                         input.val('');
                         return false;
-                    case 86: /* V */
+                    case "v":
                         if (self.eventIsCommandKey(event)) { /* cmd+V = paste */
                             self._startEdit('uncapturedText');
                             return true; /* override grid event handler, defer to browser's own */
@@ -658,32 +657,32 @@ function TextGridCell(opts) {
                 }
                 break;
             case 'capturedText':
-                switch(event.which) {
-                    case 13: /* enter */
+                switch(event.key) {
+                    case "Enter":
                         self._finishEdit();
                         return false;
-                    case 27: /* escape */
+                    case "Escape":
                         self._cancelEdit();
                         return false;
-                    case 37: /* cursors */
-                    case 38:
-                    case 39:
-                    case 40:
+                    case "ArrowLeft":
+                    case "ArrowUp":
+                    case "ArrowRight":
+                    case "ArrowDown":
                         return true; /* override grid event handler, defer to browser's own */
                 }
                 break;
             case 'uncapturedText':
-                switch(event.which) {
-                    case 13: /* enter */
+                switch(event.key) {
+                    case "Enter":
                         self._finishEdit();
                         return null; /* grid's event handler for the enter key will advance to next cell */
-                    case 27: /* escape */
+                    case "Escape":
                         self._cancelEdit();
                         return false;
-                    case 37: /* cursors */
-                    case 38:
-                    case 39:
-                    case 40:
+                    case "ArrowLeft":
+                    case "ArrowUp":
+                    case "ArrowRight":
+                    case "ArrowDown":
                         self._finishEdit();
                         return null; /* let grid event handler process the cursor movement */
                 }
@@ -738,17 +737,17 @@ function SelectGridCell(opts) {
     self.keydown = function(event) {
         switch (self._editMode) {
             case null:
-                if ( (event.which >= 48 && event.which <= 57) || (event.which >= 65 && event.which <= 90) ) {
+                if ( event.key.length === 1 ) {
                     // respond to alphanumeric keys and enter by focusing the dropdown
                     // (all prod types and platforms start with alphanumerics)
                     self._startEdit('uncapturedText');
                     return true; /* allow select box to handle the keypress */
                 } else {
-                    switch (event.which) {
-                        case 13:
+                    switch (event.key) {
+                        case "Enter":
                             self._startEdit('capturedText');
                             return false;
-                        case 8: /* backspace */
+                        case "Backspace":
                             self._startEdit('uncapturedText');
                             input.val('');
                             return false;
@@ -756,35 +755,35 @@ function SelectGridCell(opts) {
                 }
                 break;
             case 'capturedText':
-                switch(event.which) {
-                    case 13: /* enter */
+                switch(event.key) {
+                    case "Enter":
                         self._finishEdit();
                         input.blur();
                         return false;
-                    case 27: /* escape */
+                    case "Escape":
                         self._cancelEdit();
                         return false;
-                    case 37: /* cursors */
-                    case 38:
-                    case 39:
-                    case 40:
+                    case "ArrowLeft":
+                    case "ArrowUp":
+                    case "ArrowRight":
+                    case "ArrowDown":
                         return true; /* override grid event handler, defer to browser's own */
                 }
                 break;
             case 'uncapturedText':
-                switch(event.which) {
-                    case 13: /* enter */
+                switch(event.key) {
+                    case "Enter":
                         self._finishEdit();
                         input.blur();
                         return null; /* grid's event handler for the enter key will advance to next cell */
-                    case 27: /* escape */
+                    case "Escape":
                         self._cancelEdit();
                         input.blur();
                         return false;
-                    case 38: /* cursors */
-                    case 40:
-                    case 37:
-                    case 39:
+                    case "ArrowUp":
+                    case "ArrowDown":
+                    case "ArrowLeft":
+                    case "ArrowRight":
                         self._finishEdit();
                         input.blur();
                         return null; /* let grid event handler process the cursor movement */

--- a/demoscene/static/js/results_table.js
+++ b/demoscene/static/js/results_table.js
@@ -149,15 +149,15 @@ function BylineGridCell(opts) {
     self.keydown = function(event) {
         switch (self._editMode) {
             case null:
-                switch (event.which) {
-                    case 13:
+                switch (event.key) {
+                    case "Enter":
                         self._startEdit('capturedText');
                         return false;
-                    case 8: /* backspace */
+                    case "Backspace":
                         self._startEdit('uncapturedText');
                         bylineField.setValue(null);
                         return false;
-                    case 86: /* V */
+                    case "v":
                         if (self.eventIsCommandKey(event)) { /* cmd+V = paste */
                             self._startEdit('uncapturedText');
                             setTimeout(function() {bylineField.lookUpMatches();}, 10);
@@ -169,20 +169,20 @@ function BylineGridCell(opts) {
             case 'capturedText':
             case 'uncapturedText': /* no distinction between captured and uncaptured text here (except for
             whether to cancel default 'advance' event on enter) */
-                switch(event.which) {
-                    case 13: /* enter */
+                switch(event.key) {
+                    case "Enter":
                         self._finishEdit();
                         return (self._editMode == 'capturedText' ? false : null);
-                    case 27: /* escape */
+                    case "Escape":
                         self._cancelEdit();
                         return false;
-                    case 37: /* cursors */
-                    case 38:
-                    case 39:
-                    case 40:
+                    case "ArrowLeft":
+                    case "ArrowUp":
+                    case "ArrowRight":
+                    case "ArrowDown":
                         /* let bylineField handle cursor keys, unimpeded by EditableGrid behaviour */
                         return true;
-                    case 9: /* tab */
+                    case "Tab":
                         if (
                             (bylineField.firstFieldIsFocused() && event.shiftKey) ||
                             (bylineField.lastFieldIsFocused() && !event.shiftKey)
@@ -254,11 +254,11 @@ function ProductionTitleGridCell(opts) {
     self.keydown = function(event) {
         switch (self._editMode) {
             case null:
-                switch (event.which) {
-                    case 13:
+                switch (event.key) {
+                    case "Enter":
                         self._startEdit('capturedText');
                         return false;
-                    case 8: /* backspace */
+                    case "Backspace":
                         if (self._isLocked) {
                             self.requestUnlock.trigger();
                         } else {
@@ -266,7 +266,7 @@ function ProductionTitleGridCell(opts) {
                             self._input.val('');
                         }
                         return false;
-                    case 86: /* V */
+                    case "v":
                         if (self.eventIsCommandKey(event)) { /* cmd+V = paste */
                             self._startEdit('uncapturedText');
                             setTimeout(function() {
@@ -279,8 +279,8 @@ function ProductionTitleGridCell(opts) {
                 break;
             case 'capturedText':
             case 'unlock':
-                switch(event.which) {
-                    case 13: /* enter */
+                switch(event.key) {
+                    case "Enter":
                         /* we want to finish edit UNLESS this keypress causes an autocomplete item to be
                         selected, in which case we want the autocomplete's select event to fire and trigger
                         the finishEdit call *after* having processed the autocomplete event handler which
@@ -291,21 +291,21 @@ function ProductionTitleGridCell(opts) {
                             if (self._editMode) self._finishEdit();
                         }, 1);
                         return false;
-                    case 27: /* escape */
+                    case "Escape":
                         var wasUnlocking = (self._editMode == 'unlock');
                         self._cancelEdit();
                         if (wasUnlocking) self.cancelUnlock.trigger();
                         return false;
-                    case 37: /* cursors */
-                    case 38:
-                    case 39:
-                    case 40:
+                    case "ArrowLeft":
+                    case "ArrowUp":
+                    case "ArrowRight":
+                    case "ArrowDown":
                         return true; /* override grid event handler, defer to browser's own */
                 }
                 break;
             case 'uncapturedText':
-                switch(event.which) {
-                    case 13: /* enter */
+                switch(event.key) {
+                    case "Enter":
                         setTimeout(function() {
                             /* if we're still in edit mode after autocomplete.select has had chance to fire,
                                 assume we're finishing the edit in the regular way */
@@ -315,15 +315,15 @@ function ProductionTitleGridCell(opts) {
                             }
                         }, 1);
                         return false;
-                    case 27: /* escape */
+                    case "Escape":
                         self._cancelEdit();
                         return false;
-                    case 37: /* cursors left/right */
-                    case 39:
+                    case "ArrowLeft":
+                    case "ArrowRight":
                         self._finishEdit();
                         return null; /* let grid event handler process the cursor movement */
-                    case 38: /* cursors up/down */
-                    case 40:
+                    case "ArrowUp":
+                    case "ArrowDown":
                         return true; /* override grid event handler, defer to browser's own */
                 }
                 break;

--- a/demoscene/static/js/results_table.js
+++ b/demoscene/static/js/results_table.js
@@ -149,21 +149,20 @@ function BylineGridCell(opts) {
     self.keydown = function(event) {
         switch (self._editMode) {
             case null:
-                switch (event.key) {
-                    case "Enter":
-                        self._startEdit('capturedText');
-                        return false;
-                    case "Backspace":
-                        self._startEdit('uncapturedText');
-                        bylineField.setValue(null);
-                        return false;
-                    case "v":
-                        if (self.eventIsCommandKey(event)) { /* cmd+V = paste */
-                            self._startEdit('uncapturedText');
-                            setTimeout(function() {bylineField.lookUpMatches();}, 10);
-                            return true; /* override grid event handler, defer to browser's own */
-                        }
-                        break;
+                if (event.key === "Enter") {
+                    self._startEdit('capturedText');
+                    return false;
+                } else if (event.key === "Backspace") {
+                    self._startEdit('uncapturedText');
+                    bylineField.setValue(null);
+                    return false;
+                } else if (event.key === "v" && self.eventIsCommandKey(event)) {
+                    /* cmd+V = paste */
+                    self._startEdit('uncapturedText');
+                    setTimeout(function() {bylineField.lookUpMatches();}, 10);
+                    return true; /* override grid event handler, defer to browser's own */
+                } else if (event.key.length === 1) {
+                    self._startEdit('uncapturedText');
                 }
                 break;
             case 'capturedText':
@@ -194,13 +193,6 @@ function BylineGridCell(opts) {
                             return true;
                         }
                 }
-                break;
-        }
-    };
-    self.keypress = function(event) {
-        switch (self._editMode) {
-            case null:
-                self._startEdit('uncapturedText');
                 break;
         }
     };
@@ -254,27 +246,26 @@ function ProductionTitleGridCell(opts) {
     self.keydown = function(event) {
         switch (self._editMode) {
             case null:
-                switch (event.key) {
-                    case "Enter":
-                        self._startEdit('capturedText');
-                        return false;
-                    case "Backspace":
-                        if (self._isLocked) {
-                            self.requestUnlock.trigger();
-                        } else {
-                            self._startEdit('uncapturedText');
-                            self._input.val('');
-                        }
-                        return false;
-                    case "v":
-                        if (self.eventIsCommandKey(event)) { /* cmd+V = paste */
-                            self._startEdit('uncapturedText');
-                            setTimeout(function() {
-                                self._input.autocomplete('search');
-                            }, 10);
-                            return true; /* override grid event handler, defer to browser's own */
-                        }
-                        break;
+                if (event.key === "Enter") {
+                    self._startEdit('capturedText');
+                    return false;
+                } else if (event.key === "Backspace") {
+                    if (self._isLocked) {
+                        self.requestUnlock.trigger();
+                    } else {
+                        self._startEdit('uncapturedText');
+                        self._input.val('');
+                    }
+                    return false;
+                } else if (event.key === "v" && self.eventIsCommandKey(event)) {
+                    /* cmd+V = paste */
+                    self._startEdit('uncapturedText');
+                    setTimeout(function() {
+                        self._input.autocomplete('search');
+                    }, 10);
+                    return true; /* override grid event handler, defer to browser's own */
+                } else if (event.key.length === 1) {
+                    self._startEdit('uncapturedText');
                 }
                 break;
             case 'capturedText':


### PR DESCRIPTION
An annoyance that has probably been around for ages, but I only just discovered it when switching from Chrome to Firefox: if you have a cell of the results table highlighted (but not actively in edit mode) and start typing, the first character will switch you to edit mode on Firefox but that character will not actually be entered into the input box.

This is because we relied on an apparently Chrome-specific quirk: if you set the focus to another element during a keypress event handler, and don't cancel the event by returning false, the newly-focused element will receive the keypress and process it as normal. This isn't the case on Firefox - to get around this, we move the event handler to the keydown event (and use `event.key.length === 1` to identify keypresses corresponding to printable characters), so that the input is already focused by the time the keypress event happens.