### PR TITLE
Download link descriptions

### DIFF
--- a/demoscene/static/js/lightbox.js
+++ b/demoscene/static/js/lightbox.js
@@ -32,8 +32,20 @@
         isShowing = true;
 
         if (opts && opts.focusEmptyInput) {
-            /* focus on the first *empty* input field */
-            try {$(':input:visible[value=""]', lightboxContent)[0].focus();}catch(_){}
+            const spawnedForms = lightboxContent.find('.spawned_form');
+            if (spawnedForms.length) {
+                /* focus on the first spawned form whose first visible input is empty */
+                spawnedForms.each(function() {
+                    const firstInput = $(':input:visible', this).first();
+                    if (firstInput.length && firstInput.val() === '') {
+                        firstInput.focus();
+                        return false; // stop the each loop
+                    }
+                });
+            } else {
+                /* focus on the first empty input field */
+                try {$(':input:visible[value=""]', lightboxContent)[0].focus();}catch(_){}
+            }
         } else {
             try {$(':input:visible', lightboxContent)[0].focus();}catch(_){}
         }

--- a/demoscene/templates/groups/show.html
+++ b/demoscene/templates/groups/show.html
@@ -32,7 +32,7 @@
                 {% endif %}
                 {% if prompt_to_edit %}
                     <li>
-                        {% edit_button url=group.urls.edit_primary_nick classname="edit_chunk" lightbox=True focus_empty=True title="Edit name" nofollow=True %}
+                        {% edit_button url=group.urls.edit_primary_nick classname="edit_chunk" lightbox=True title="Edit name" nofollow=True %}
                     </li>
                 {% endif %}
             </ul>

--- a/demoscene/templates/sceners/show.html
+++ b/demoscene/templates/sceners/show.html
@@ -32,7 +32,7 @@
                 {% endif %}
                 {% if prompt_to_edit %}
                     <li>
-                        {% edit_button url=scener.urls.edit_primary_nick classname="edit_chunk" lightbox=True focus_empty=True title="Edit name" nofollow=True %}
+                        {% edit_button url=scener.urls.edit_primary_nick classname="edit_chunk" lightbox=True title="Edit name" nofollow=True %}
                     </li>
                 {% endif %}
             </ul>

--- a/productions/forms.py
+++ b/productions/forms.py
@@ -291,11 +291,12 @@ class ProductionDownloadLinkForm(ExternalLinkForm):
             "link_class",
             "production",
             "is_download_link",
-            "description",
             "demozoo0_id",
             "file_for_screenshot",
             "is_unresolved_for_screenshotting",
         ]
+
+        widgets = {"description": forms.TextInput(attrs={"placeholder": 'Optional description, like "party version"'})}
 
 
 ProductionDownloadLinkFormSet = inlineformset_factory(

--- a/productions/templates/productions/edit_links.html
+++ b/productions/templates/productions/edit_links.html
@@ -3,12 +3,16 @@
 
 {% block form_body %}
     <div class="field">
-        <label for="id_external_links-0-url" class="field_label">Link URLs</label>
+        <label for="id_links-0-url" class="field_label">Link URLs</label>
         <div class="field_input">
             {% spawningformset formset %}
                 {% spawningform as form %}
                     {{ form.url }}
                     {{ form.url.errors }}
+                    {% if form.description %}
+                        {{ form.description }}
+                        {{ form.description.errors }}
+                    {% endif %}
                     {% for hidden in form.hidden_fields %}
                         {{ hidden }}
                     {% endfor %}

--- a/productions/templates/productions/includes/downloads_panel.html
+++ b/productions/templates/productions/includes/downloads_panel.html
@@ -19,6 +19,7 @@
         {% for link in download_links %}
             <li class="download_link {{ link.html_link_class }}">
                 {{ link.as_download_link|safe }}
+                {% if link.description %}({{ link.description }}){% endif %}
             </li>
         {% endfor %}
     </ul>

--- a/productions/views/productions.py
+++ b/productions/views/productions.py
@@ -329,6 +329,7 @@ class DeleteBlurbView(AjaxConfirmationView):
 
 class EditLinksView(EditingView):
     template_name = "productions/edit_links.html"
+    html_form_class = ""
 
     def prepare(self, request, production_id):
         self.production = get_object_or_404(Production, id=production_id)
@@ -365,6 +366,7 @@ class EditLinksView(EditingView):
                 "action_url": reverse(self.action_url_name, args=[self.production.id]),
                 "formset": self.formset,
                 "submit_button_label": "Update links",
+                "html_form_class": self.html_form_class,
             }
         )
         return context
@@ -375,6 +377,7 @@ class EditExternalLinksView(EditLinksView):
     is_download_link = False
     log_action_type = "production_edit_external_links"
     action_url_name = "production_edit_external_links"
+    html_form_class = "external_links_form"
 
     def get_title(self):
         return f"Editing external links for {self.production.title}"
@@ -385,6 +388,7 @@ class EditDownloadLinksView(EditLinksView):
     is_download_link = True
     log_action_type = "production_edit_download_links"
     action_url_name = "production_edit_download_links"
+    html_form_class = "download_links_form"
 
     def get_title(self):
         return f"Editing download links for {self.production.title}"

--- a/src/style/assets/_form.scss
+++ b/src/style/assets/_form.scss
@@ -111,15 +111,9 @@ fieldset {
     }
 }
 
-/* external links form needs bigger labels */
-.external_links_form .field {
-
-    label.field_label {
-        width: 200px;
-    }
-
-    .field_input {
-        width: 400px;
+.download_links_form {
+    .spawned_form {
+        margin-bottom: 1em;
     }
 }
 


### PR DESCRIPTION
Rebase of @jensadne 's PR #351 with some tweaks:

* Only applies to download links for now - I think external links will need a different kind of UI where the description comes into play only after we've failed to match the link against a recognised type (and thus it takes the place of the 'WWW' label)
* Added extra margin between sub-forms of the download links form, to make it clearer which fields are grouped together
* Modified the behaviour of the "focus the first empty field" mode of the lightbox so that it looks for the first sub-form whose first visible field is empty (which in this case will be the place to paste in a new URL, rather than the empty description field of the first existing link).

I'm still a little wary that some people will use the field for editorialising about the demo itself (description = "a cool demo with metaballs and nice music") - hopefully the detailed hint text will be enough of a steer, but we can reconsider that if necessary after seeing how it's used in the wild.