### PR TITLE
Enhance scene.org compo file matching (directory level)

### DIFF
--- a/sceneorg/templates/sceneorg/compofiles/index.html
+++ b/sceneorg/templates/sceneorg/compofiles/index.html
@@ -1,11 +1,15 @@
 {% extends "base.html" %}
 {% load compress %}
+{% block extra_js %}
+    {% compress js %}<script src="/static/maintenance/js/maintenance.js"></script>{% endcompress %}
+{% endblock %}
 
 
 {% block base_main %}
     <h2>scene.org party file matching</h2>
     <p>Another chance to do some hypnotic button clicking to help with our data entry! Now that we know which folders on scene.org correspond to which party compos, it's time to match up the individual download files to the correct compo entries.</p>
-    <p>Pick a folder from the list below - the ones in <strong>bold</strong> contain some uncategorised files that haven't yet been attached to a production as a download link. Your mission is to match them up to the appropriate compo entry...</p>
+    <p>Pick a folder from the list below{% if mode == 'all' %} - the ones in <strong>bold</strong> contain some uncategorised files that haven't yet been attached to a production as a download link. Your mission is to match them up to the appropriate compo entry..{% endif %}.</p>
+    <p>Click <a href="{% url 'sceneorg_compofiles' %}{% if mode != 'all' %}?mode=all{% endif %}">here</a> to {% if mode == 'unmatched' %}also show{% else %}hide{% endif %} directories that are fully matched.</p>
 
     <div style="width: 300px; float: right; border: 1px solid #ccc; padding: 10px;">
         <h3>Leaderboard</h3>
@@ -16,10 +20,10 @@
         </ol>
     </div>
 
-    <ul class="folders">
+    <ul class="folders report" data-report-name="{{ exclusion_name }}" style="border: 0px; padding: 0px; margin: 0px">
         {% for dir in directories %}
-            <li>
-                {% if dir.unmatched_count == 0 %}
+            <li{% if mark_excludable and site_is_writeable %} class="excludable" data-record-id="{{ dir.id }}"{% endif %}>
+                {% if dir.unmatched_count == 0 and mode == 'all' %}
                     <a href="{% url 'sceneorg_compofile_directory' dir.id %}">{{ dir.path }}</a>
                 {% else %}
                     <strong><a href="{% url 'sceneorg_compofile_directory' dir.id %}">{{ dir.path }}</a></strong> ({{ dir.unmatched_count }})

--- a/sceneorg/views.py
+++ b/sceneorg/views.py
@@ -7,6 +7,7 @@ from django.shortcuts import get_object_or_404, redirect, render
 
 from common.views import writeable_site_required
 from demoscene.models import Edit
+from maintenance.models import Exclusion
 from parties.models import Competition, Party
 from productions.models import Production, ProductionLink
 from sceneorg.models import Directory, File
@@ -141,7 +142,15 @@ def compofiles(request):
     # annotated with the number of files in the directory,
     # and the number of those files which are used as a download link for some production.
     # Where these numbers differ, there are files in the directory which are unaccounted for.
-    directories = Directory.objects.raw("""
+
+    # valid modes = "unmatched" (as a default), "all"
+    mode = request.GET.get("mode", "unmatched")
+
+    excluded_ids = Exclusion.objects.filter(report_name="sceneorg_compofiles").values_list(
+        "record_id", flat=True
+    )
+
+    base_query = """
         SELECT
             sceneorg_directory.id, sceneorg_directory.path,
             COUNT(DISTINCT sceneorg_file.id) - COUNT(DISTINCT productions_productionlink.parameter) AS unmatched_count
@@ -163,10 +172,33 @@ def compofiles(request):
             )
         WHERE
             sceneorg_directory.is_deleted = 'f'
+            {exclude_by_id_condition}
         GROUP BY
             sceneorg_directory.id, sceneorg_directory.path
+        {exclude_fully_matched_condition}
         ORDER BY sceneorg_directory.path
-    """)
+    """
+    # Prepare parameters and conditions
+    conditions = {}
+
+    # Handle excluded IDs
+    if excluded_ids:
+        conditions['exclude_by_id_condition'] = 'AND sceneorg_directory.id NOT IN {}'.format(tuple(excluded_ids))
+    else:
+        conditions['exclude_by_id_condition'] = ''
+
+    # Handle unmatched mode
+    if mode == 'unmatched':
+        conditions['exclude_fully_matched_condition'] = 'HAVING (COUNT(DISTINCT sceneorg_file.id) - ' \
+        'COUNT(DISTINCT productions_productionlink.parameter)) > 0'
+    else:
+        conditions['exclude_fully_matched_condition'] = ''
+
+    # Format the query with conditions
+    formatted_query = base_query.format(**conditions)
+
+    # Execute the query
+    directories = Directory.objects.raw(formatted_query)
 
     top_users = User.objects.raw("""
         SELECT
@@ -194,6 +226,9 @@ def compofiles(request):
         {
             "directories": directories,
             "top_users": top_users,
+            "mode": mode,
+            "mark_excludable": True,
+            "exclusion_name": "sceneorg_compofiles",
         },
     )
 


### PR DESCRIPTION
Following the enhancement requests in https://github.com/demozoo/demozoo/issues/498, this adds the possibility to show/hide fully matched directories as well as the functionality to exclude directories from being listed again (for those where there is nothing to match).