### PR TITLE
Fix scene.org result file recognition when called results.nfo

### DIFF
--- a/parties/models.py
+++ b/parties/models.py
@@ -224,7 +224,8 @@ class Party(URLMixin, LocationMixin, Commentable):
 
         sceneorg_dirs = self.external_links.filter(link_class="SceneOrgFolder")
         for sceneorg_dir in sceneorg_dirs:
-            for subpath in ["info/results.txt", "misc/results.txt", "results.txt"]:
+            for subpath in ["info/results.txt", "misc/results.txt", "results.txt", "info/results.nfo",
+                            "misc/results.nfo"]:
                 try:
                     return SceneOrgFile.objects.get(path=sceneorg_dir.parameter + subpath, is_deleted=False)
                 except SceneOrgFile.DoesNotExist:


### PR DESCRIPTION
Add results.nfo recognition in misc and info subdirectories