### PR TITLE
Fix link recognition for Deepsid profiles

### DIFF
--- a/common/utils/groklinks.py
+++ b/common/utils/groklinks.py
@@ -391,14 +391,14 @@ class DeepSIDProfile(AbstractBaseUrl):
     site = deepsid
     canonical_format = "https://deepsid.chordian.net/?file=/MUSICIANS/%s"
     tests = [
-        regex_match(r"^https?://deepsid\.chordian\.net/\?file=/MUSICIANS/([^/]+/[^/.]+)(?!.*.sid)[\/]?"),
+        regex_match(r"^https?://deepsid\.chordian\.net/\?file=/?MUSICIANS/([^/]+/[^/.]+)(?!.*\.sid)[\/]?"),
         regex_match(
             r"^https?://deepsid\.chordian\.net/\?file=/_High Voltage SID Collection/MUSICIANS/"
-            r"([^/]+/[^/.]+)(?!.*.sid)[\/]?"
+            r"([^/]+/[^/.]+)(?!.*\.sid)[\/]?"
         ),
         regex_match(
             r"^https?://deepsid\.chordian\.net/\?file=/_High%20Voltage%20SID%20Collection/MUSICIANS/"
-            r"([^/]+/[^/.]+)(?!.*.sid)[\/]?"
+            r"([^/]+/[^/.]+)(?!.*\.sid)[\/]?"
         ),
     ]
 


### PR DESCRIPTION
The profile link recognitation had flaws: I did not recognize links when the URL didn't containt file=/MUSICIAN however, a common pattern is also file=MUSICIAN... (when just going to DeepSID, search for an artists and copy&paste link, ...). 
Also the exclusion of links ending with .sid was didn't work as the dot in _.sid_ matched any character. Had to escape the dot to match actual _.sid_.