### PR TITLE
Add two simple reports to find html hyperlinks in prod and releaser notes

### DIFF
--- a/maintenance/tests/test_views.py
+++ b/maintenance/tests/test_views.py
@@ -210,6 +210,14 @@ class TestReports(TestCase):
         response = self.client.get("/maintenance/prods_with_blurbs/")
         self.assertEqual(response.status_code, 200)
 
+    def text_prod_notes_with_html_links(self):
+        response = self.client.get("/maintenance/prod_notes_with_html_links/")
+        self.assertEqual(response.status_code, 200)
+
+    def text_releaser_notes_with_html_links(self):
+        response = self.client.get("/maintenance/releaser_notes_with_html_links/")
+        self.assertEqual(response.status_code, 200)
+
     def test_prod_comments(self):
         response = self.client.get("/maintenance/prod_comments/")
         self.assertEqual(response.status_code, 200)

--- a/maintenance/views.py
+++ b/maintenance/views.py
@@ -1268,6 +1268,59 @@ class PublicRealNames(StaffOnlyMixin, Report):
         return context
 
 
+class HtmlHyperlinksInProductionNotes(StaffOnlyMixin, Report):
+    title = "Production notes with HTML links"
+    template_name = "maintenance/production_report.html"
+    name = "prod_notes_with_html_links"
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+
+        productions = (
+            Production.objects.exclude(notes="")
+                # .filter(notes__contains="<a") did not work here for performance reasons, not sure
+                # why the following regexp is faster though ;-)
+                .extra(where=["productions_production.notes ~ '<a[^>]*href'"])
+                .distinct()
+                .prefetch_related("author_nicks__releaser", "author_affiliation_nicks__releaser")
+                .order_by("title")
+        )
+        context.update(
+            {
+                "productions": productions,
+                # don't implement exclusions on this report, because it's possible that html hyperlinks
+                # will be introduced to notes later on
+                "mark_excludable": False,
+            }
+        )
+        return context
+
+
+class HtmlHyperlinksInReleaserNotes(StaffOnlyMixin, Report):
+    title = "Releaser notes with HTML links"
+    template_name = "maintenance/releaser_report.html"
+    name = "releaser_notes_with_html_links"
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+
+        releasers = (
+            Releaser.objects.filter(notes__contains="<a")
+                .distinct()
+                .order_by("name")
+        )
+
+        context.update(
+            {
+                "releasers": releasers,
+                # don't implement exclusions on this report, because it's possible that html hyperlinks
+                # will be introduced to notes later on. this is achieved by setting the "exclusion_name"
+                # to empty string.
+                "exclusion_name": "",
+            }
+        )
+        return context
+
 class ProdsWithBlurbs(StaffOnlyMixin, Report):
     title = "Productions with blurbs"
     template_name = "maintenance/prods_with_blurbs.html"
@@ -1943,6 +1996,8 @@ reports = [
             CreditsToMoveToText,
             SceneorgDownloadLinksWithUnicode,
             EmptyCompetitions,
+            HtmlHyperlinksInProductionNotes,
+            HtmlHyperlinksInReleaserNotes,
         ],
     ),
     (


### PR DESCRIPTION
As requested in the admin channel, here are two reports to find HTML hyperlinks in production and releaser notes. Parties, BBSs and so on are not available.