### PR TITLE
Changed to the new Fujiology URL

### DIFF
--- a/common/tests/test_groklinks.py
+++ b/common/tests/test_groklinks.py
@@ -68,9 +68,16 @@ class TestLinkRecognition(TestCase):
     def test_fujiology_folder(self):
         forever2e3 = Party.objects.get(name="Forever 2e3")
         link = PartyExternalLink(party=forever2e3)
-        link.url = "ftp://fujiology.untergrund.net/users/ltk_tscc/fujiology/parties/2000/forever00"
+        link.url = "ftp://fujiology.untergrund.net/users/ltk_tscc/fujiology/PARTIES/2000/FOREVER00"
         self.assertEqual(link.link_class, "FujiologyFolder")
-        self.assertEqual(link.parameter, "/parties/2000/forever00/")
+        self.assertEqual(link.parameter, "/PARTIES/2000/FOREVER00/")
+
+    def test_fujiology_folder2(self):
+        forever2e3 = Party.objects.get(name="Forever 2e3")
+        link = PartyExternalLink(party=forever2e3)
+        link.url = "https://fujiology.org/PARTIES/2000/FOREVER00"
+        self.assertEqual(link.link_class, "FujiologyFolder")
+        self.assertEqual(link.parameter, "/PARTIES/2000/FOREVER00/")
 
     def test_pouet_party_needs_query_params(self):
         forever2e3 = Party.objects.get(name="Forever 2e3")

--- a/common/utils/groklinks.py
+++ b/common/utils/groklinks.py
@@ -890,29 +890,30 @@ class ModlandFile(AbstractBaseUrl):
 
 fujiology = Site(
     "Fujiology",
-    long_name="the Fujiology Archive",
-    url="https://ftp.untergrund.net/",
+    long_name="the Fujiology archive",
+    url="https://fujiology.org/",
     allowed_schemes=["https", "ftp"],
-    allowed_hostnames=["ftp.untergrund.net", "fujiology.untergrund.net"],
+    allowed_hostnames=["fujiology.org", "www.fujiology.org", "ftp.untergrund.net",
+                       "fujiology.untergrund.net", "untergrund.net"],
 )
-
 
 class FujiologyFile(AbstractBaseUrl):
     site = fujiology
-    canonical_format = "https://ftp.untergrund.net/users/ltk_tscc/fujiology%s"
+    canonical_format = "https://fujiology.org%s"
     tests = [
+        regex_match(r"https://(?:www\.)?fujiology\.org(/.*)"),
+        regex_match(r"(?:https|ftp)://(?:fujiology\.|ftp\.)?untergrund\.net/users/ltk_tscc/fujiology(/.*)"),
         path_regex_match(r"/users/ltk_tscc/fujiology(/.*)"),
     ]
-    download_link_label = "Fujiology @ untergrund.net"
+    download_link_label = "fujiology.org"
 
 
 class FujiologyFolder(AbstractBaseUrl):
     site = fujiology
-    canonical_format = "https://ftp.untergrund.net/users/ltk_tscc/fujiology%s"
+    canonical_format = "https://fujiology.org%s"
     tests = [
-        regex_match(
-            r"(?:https|ftp)://(?:fujiology\.|ftp\.)?untergrund\.net/users/ltk_tscc/fujiology(/.*)", add_slash=True
-        ),
+        regex_match(r"https://(?:www\.)?fujiology\.org(/.*)", add_slash=True),
+        regex_match(r"(?:https|ftp)://(?:fujiology\.|ftp\.)?untergrund\.net/users/ltk_tscc/fujiology(/.*)", add_slash=True),
     ]
 
 

--- a/common/utils/groklinks.py
+++ b/common/utils/groklinks.py
@@ -913,7 +913,8 @@ class FujiologyFolder(AbstractBaseUrl):
     canonical_format = "https://fujiology.org%s"
     tests = [
         regex_match(r"https://(?:www\.)?fujiology\.org(/.*)", add_slash=True),
-        regex_match(r"(?:https|ftp)://(?:fujiology\.|ftp\.)?untergrund\.net/users/ltk_tscc/fujiology(/.*)", add_slash=True),
+        regex_match(r"(?:https|ftp)://(?:fujiology\.|ftp\.)?untergrund\.net/users/ltk_tscc/fujiology(/.*)",
+                    add_slash=True),
     ]
 
 


### PR DESCRIPTION
Added recognition of the new Fujiology URL, also recognized old untergrund.net URLs. 
Returns/shows fujiuology.org download links only.