### PR TITLE
Set link_label of generic WWW links so that it contains the hostname.

### DIFF
--- a/common/utils/groklinks.py
+++ b/common/utils/groklinks.py
@@ -176,6 +176,11 @@ class BaseUrl(AbstractBaseUrl):  # catch-all handler where nothing more specific
     ]
     canonical_format = "%s"
 
+    @property
+    def link_label(self):
+        url = urllib.parse.urlparse(self.param)
+        return "WWW (%s)" % url.hostname
+
 
 def regex_match(pattern, flags=re.IGNORECASE, add_slash=False):
     """


### PR DESCRIPTION
As discussed on Discord, this should help to identify/disambiguate WWW links.